### PR TITLE
Amplitude estimation without inverse QFT and controlled Q-operators

### DIFF
--- a/algorithms/SimpleIntegral_AEwoPE.ipynb
+++ b/algorithms/SimpleIntegral_AEwoPE.ipynb
@@ -1,0 +1,716 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amplitude Estimation without Quantum Fourier Transform and Controlled Grover Operators\n",
+    "\n",
+    "\n",
+    "## Contributors\n",
+    "\n",
+    "Based on the paper [Amplitude Estimation without Phase Estimation](https://arxiv.org/abs/1904.10246). \n",
+    "\n",
+    "Written by Tomoki Tanaka (MUFG Bank), Shumpei Uno (Mizuho Information and Research Institute), Yohichi Suzuki (Keio University), and Rudy Raymond (IBM). \n",
+    "\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "This notebook contains experiments for performing amplitude estimation without inverse Quantum Fourier Transform (QFT) and controlled Q-operators (aka., Grover operators). It is known that without QFT and such controlled operators, the number of two-qubit gates (e.g., CNOT gates) required for running amplitude estimation can be reduced, and hence may be more appropriate to run quantum algorithms on Noisy Intermediate Scale Quantum (NISQ) devices. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "We consider applying amplitude estimation, one of the most popular quantum algorithms, for Monte Carlo integration, a problem which is essential for financial applications. The purpose of Monte Carlo integration is to compute the expected value of a real-valued function $f$. Here, for simplicity we assume $f$ takes an $n$-bit input $x \\in \\{0,1\\}^n$, $0 \\le f(x) \\le 1$, and the probability of $f(x)$ is $p(x)$. Then, the expected value is \n",
+    "$$\n",
+    "\\mathbb{E}[f(x)] = \\sum_{x=0}^{2^n-1} p(x) f(x)\n",
+    "$$\n",
+    "\n",
+    "To compute the Monte Carlo integration of $f$, let us assume that quantum circuits $\\mathcal{P}$ and $\\mathcal{R}$, that perform the following transformation, are given. \n",
+    "\\begin{eqnarray}\n",
+    "\\mathcal{P} \\left|0\\right>_n &=& \\sum_{x} \\sqrt{p(x)} \\left|x\\right>_n\\\\\n",
+    "\\mathcal{R} \\left|x\\right>_n\\left|0\\right> &=& \\left|x\\right>_n \\left( \\sqrt{f(x)} \\left|1\\right> + \\sqrt{1-f(x)} \\left|0\\right>\\right) \n",
+    "\\end{eqnarray}\n",
+    "The former is for creating probability distribution $p(\\cdot)$, and the latter for computing $f(\\cdot)$. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Integral of sine functions\n",
+    "\n",
+    "Following Section 4.2 of [\"Amplitude Estimation without Phase Estimation\", by Suzuki et al.](https://arxiv.org/abs/1904.10246), we consider the following integral \n",
+    "$$\n",
+    "\\mathcal{I} = \\frac{1}{b_\\mbox{max}}\\int_{0}^{b_\\mbox{max}} \\sin^2{x}~dx,\n",
+    "$$\n",
+    "which is approximated with the following summation\n",
+    "\n",
+    "$$\n",
+    "\\mathcal{S} = \\sum_{x=0}^{2^n-1} \\frac{1}{2^n} \\sin^2{\\left(  \\frac{\\left(x+1/2\\right)b_{\\mbox{max}}}{2^n}  \\right)}.\n",
+    "$$\n",
+    "\n",
+    "This means, we the quantum circuits $\\mathcal{P}$ and $\\mathcal{R}$ are\n",
+    "\\begin{eqnarray}\n",
+    "\\mathcal{P} \\left|0\\right>_n \\left|0\\right> &=& \\frac{1}{\\sqrt{2^n}} \\sum_{x} \\left|x\\right>_n \\left|0\\right>\\\\\n",
+    "\\mathcal{R} \\left|x\\right>_n\\left|0\\right> &=& \\left|x\\right>_n \\left(    \\sin{\\left(  \\frac{\\left(x+1/2\\right)b_{\\mbox{max}}}{2^n}  \\right)} \\left|1\\right> +   \\cos{\\left(  \\frac{\\left(x+1/2\\right)b_{\\mbox{max}}}{2^n}  \\right)} \\left|0\\right>\\right).\n",
+    "\\end{eqnarray}\n",
+    "\n",
+    "$\\mathcal{P}$ can be realized with Hadamard gates, and $\\mathcal{R}$ with controlled-$Y$ rotation gates. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Approximating the integral\n",
+    "\n",
+    "It is easy to see that as we use large $n$ (i.e., more qubits) and thus larger $b_{\\mbox{max}}$, we can approximate the integral better as illustrated below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Analytical Result: 0.12158663567967151\n",
+      "Discretized Result: 0.1211973148745352\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "\n",
+    "b_max = math.pi / 5  # upper limit of integral\n",
+    "nbit = 3  # change this value to get discretized result closer to analytical results\n",
+    "\n",
+    "analyticResult = (b_max / 2.0 - math.sin(2 * b_max) / 4.0 ) / b_max  # the target integral can be analytically solved\n",
+    "print(\"Analytical Result:\", analyticResult)\n",
+    "\n",
+    "ndiv = 2**nbit  #number of discretization \n",
+    "discretizedResult = 0.0\n",
+    "for i in range(ndiv):\n",
+    "    discretizedResult += math.sin(b_max / ndiv * (i + 0.5))**2\n",
+    "discretizedResult = discretizedResult / ndiv\n",
+    "print(\"Discretized Result:\", discretizedResult)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Implementing circuits for Monte Carlo integration of sine functions\n",
+    "\n",
+    "Below are the functions to compute $\\mathcal{P}$, $\\mathcal{R}$, and their inverses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def P(qc, qx, nbit):\n",
+    "    \"\"\"\n",
+    "        Generating uniform probability distribution\n",
+    "            qc: quantum circuit\n",
+    "            qx: quantum register\n",
+    "            nbit: number of qubits\n",
+    "        The inverse of P = P\n",
+    "    \"\"\"\n",
+    "    qc.h(qx)\n",
+    "\n",
+    "def R(qc, qx, qx_measure, nbit, b_max):\n",
+    "    \"\"\"\n",
+    "        Computing the integral function f()\n",
+    "            qc: quantum circuit\n",
+    "            qx: quantum register\n",
+    "            qx_measure: quantum register for measurement\n",
+    "            nbit: number of qubits\n",
+    "            b_max: upper limit of integral            \n",
+    "    \"\"\"\n",
+    "    qc.ry(b_max / 2**nbit * 2 * 0.5, qx_measure)\n",
+    "    for i in range(nbit):\n",
+    "        qc.cu3(2**i * b_max / 2**nbit * 2, 0, 0, qx[i], qx_measure[0])\n",
+    "\n",
+    "def Rinv(qc, qx, qx_measure, nbit, b_max):\n",
+    "    \"\"\"\n",
+    "        The inverse of R\n",
+    "            qc: quantum circuit\n",
+    "            qx: quantum register\n",
+    "            qx_measure : quantum register for measurement\n",
+    "            nbit: number of qubits\n",
+    "            b_max: upper limit of integral\n",
+    "    \"\"\"\n",
+    "    for i in range(nbit)[::-1]:\n",
+    "        qc.cu3(-2**i * b_max / 2**nbit * 2, 0, 0, qx[i], qx_measure[0])\n",
+    "    qc.ry(-b_max / 2**nbit * 2 * 0.5, qx_measure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Grover Operators for Amplitude Estimation\n",
+    "\n",
+    "We can easily build quantum circuits for fast computation of the Monte Carlo integration as below. Here, we show functions to construct quantum circuits running with simulators. Running them on real devices should be easy by adjusting the parameters of the functions.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Preparing qiskit environment\n",
+    "from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit\n",
+    "from qiskit import execute\n",
+    "from qiskit import IBMQ\n",
+    "from qiskit import Aer\n",
+    "from scipy import optimize\n",
+    "import sys, time\n",
+    "import mpmath as mp\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Functions to construct circuits for Grover operators\n",
+    "def multi_control_NOT(qc, qx, qx_measure, qx_ancilla, nbit, b_max):\n",
+    "    \"\"\"\n",
+    "        Computing multi controlled NOT gate\n",
+    "            qc: quantum circuit\n",
+    "            qx: quantum register\n",
+    "            qx_measure: quantum register for measurement\n",
+    "            qx_ancilla: temporal quantum register for decomposing multi controlled NOT gate\n",
+    "            nbit: number of qubits\n",
+    "            b_max: upper limit of integral\n",
+    "    \"\"\"\n",
+    "\n",
+    "    if nbit == 1:\n",
+    "        qc.cz(qx[0], qx_measure[0])\n",
+    "    elif nbit == 2:\n",
+    "        qc.h(qx_measure[0])\n",
+    "        qc.ccx(qx[0], qx[1], qx_measure[0])\n",
+    "        qc.h(qx_measure[0])\n",
+    "    elif nbit > 2.0:\n",
+    "        qc.ccx(qx[0], qx[1], qx_ancilla[0])\n",
+    "        for i in range(nbit - 3):\n",
+    "            qc.ccx(qx[i + 2], qx_ancilla[i], qx_ancilla[i + 1])\n",
+    "        qc.h(qx_measure[0])\n",
+    "        qc.ccx(qx[nbit - 1], qx_ancilla[nbit - 3], qx_measure[0])\n",
+    "        qc.h(qx_measure[0])\n",
+    "        for i in range(nbit - 3)[::-1]:\n",
+    "            qc.ccx(qx[i + 2], qx_ancilla[i], qx_ancilla[i + 1])\n",
+    "        qc.ccx(qx[0], qx[1], qx_ancilla[0])\n",
+    "\n",
+    "\n",
+    "def reflect(qc, qx, qx_measure, qx_ancilla, nbit, b_max):\n",
+    "    \"\"\"\n",
+    "        Computing reflection operator (I - 2|0><0|)\n",
+    "            qc: quantum circuit\n",
+    "            qx: quantum register\n",
+    "            qx_measure: quantum register for measurement\n",
+    "            qx_ancilla: temporal quantum register for decomposing multi controlled NOT gate\n",
+    "            nbit: number of qubits\n",
+    "            b_max: upper limit of integral\n",
+    "    \"\"\"\n",
+    "    for i in range(nbit):\n",
+    "        qc.x(qx[i])\n",
+    "    qc.x(qx_measure[0])\n",
+    "    qc.barrier()    #format the circuits visualization\n",
+    "    multi_control_NOT(qc, qx, qx_measure, qx_ancilla, nbit, b_max)\n",
+    "    qc.barrier()    #format the circuits visualization\n",
+    "    qc.x(qx_measure[0])\n",
+    "    for i in range(nbit):\n",
+    "        qc.x(qx[i])\n",
+    "\n",
+    "\n",
+    "# This is to implement Grover Operator\n",
+    "def Q_grover(qc, qx, qx_measure, qx_ancilla, nbit, b_max):\n",
+    "    \"\"\"\n",
+    "        The Grover operator: R P (I - 2|0><0|) P^+ R^+ U_psi_0 \n",
+    "            qc: quantum circuit\n",
+    "            qx: quantum register\n",
+    "            qx_measure: quantum register for measurement\n",
+    "            qx_ancilla: temporal quantum register for decomposing multi controlled NOT gate\n",
+    "            nbit: number of qubits\n",
+    "            b_max: upper limit of integral\n",
+    "    \"\"\"\n",
+    "    qc.z(qx_measure[0])\n",
+    "    Rinv(qc, qx, qx_measure, nbit, b_max)\n",
+    "    qc.barrier()    #format the circuits visualization\n",
+    "    P(qc, qx, nbit)\n",
+    "    reflect(qc, qx, qx_measure, qx_ancilla, nbit, b_max)\n",
+    "    P(qc, qx, nbit)\n",
+    "    qc.barrier()    #format the circuits visualization\n",
+    "    R(qc, qx, qx_measure, nbit, b_max)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Amplitude Estimation without Phase Estimation\n",
+    "\n",
+    "To run the amplitude estimation without phase estimation of [Suzuki et al.](https://arxiv.org/abs/1904.10246), we must create quantum circuits that run Grover operators with various number of iterations. The function for creating such circuits is as the following."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_grover_circuit(numebr_grover_list, nbit, b_max):\n",
+    "    \"\"\"\n",
+    "        To generate quantum circuits running Grover operators with number of iterations in number_grover_list\n",
+    "            numebr_grover_list: list of number of Grover operators\n",
+    "            nbit: number of qubits (2**nbit = ndiv is the number of discretization in the Monte Carlo integration)\n",
+    "            b_max: upper limit of integral\n",
+    "        Return:\n",
+    "            qc_list: quantum circuits with Grover operators as in number_grover_list\n",
+    "    \"\"\"\n",
+    "    qc_list = []\n",
+    "    for igrover in range(len(numebr_grover_list)):\n",
+    "        qx = QuantumRegister(nbit)\n",
+    "        qx_measure = QuantumRegister(1)\n",
+    "        cr = ClassicalRegister(1)\n",
+    "        if (nbit > 2):\n",
+    "            qx_ancilla = QuantumRegister(nbit - 2)\n",
+    "            qc = QuantumCircuit(qx, qx_ancilla, qx_measure, cr)\n",
+    "        else:\n",
+    "            qx_ancilla = 0\n",
+    "            qc = QuantumCircuit(qx, qx_measure, cr)\n",
+    "        P(qc, qx, nbit)\n",
+    "        R(qc, qx, qx_measure, nbit, b_max)\n",
+    "        for ikAA in range(numebr_grover_list[igrover]):\n",
+    "            Q_grover(qc, qx, qx_measure, qx_ancilla, nbit, b_max)\n",
+    "        qc.measure(qx_measure[0], cr[0])\n",
+    "        qc_list.append(qc)\n",
+    "    return qc_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, quantum circuit with two Grover operators is shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABCoAAATuCAYAAAALLMJoAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvNQv5yAAAIABJREFUeJzs3X1cVHXe//E3N4Uad6YkKd7vZW14M4RkUgh2mdSK0iVq7raWuWplumsqQdZj14eZYnm5apuVu5UWWT9JC7pZrFxhLV0aNTS9alvy3jXvElDJTJjfH13M5SjCjAznnBlez8djHo86c5jvZz4cz3znzbkJcDgcDgEAAAAAAFhAoNkFAAAAAAAA1CKoAAAAAAAAlkFQAQAAAAAALIOgAgAAAAAAWAZBBQAAAAAAsAyCCgAAAAAAYBkEFQAAAAAAwDIIKgAAAAAAgGUQVAAAAAAAAMsgqAAAAAAAAJZBUAEAAAAAACyDoAIAAAAAAFgGQQUAAAAAALAMggoAAAAAAGAZBBUAAAAAAMAyCCoAAAAAAIBlEFQAAAAAAADLIKgAAAAAAACWQVABAAAAAAAsg6ACAAAAAABYBkEFAAAAAACwDIIKAAAAAABgGQQVAAAAAADAMggqAAAAAACAZRBUAAAAAAAAyyCoAAAAAAAAlkFQAQAAAAAALIOgAgAAAAAAWAZBBQAAAAAAsAyCCgAAAAAAYBnBZhcA65g6dapKS0tNGdtms2nRokWmjA0AAAB4m6/Orc2qm+8DOB9HVMCptLTUlJ2SWeMCAAAATcVX59Zm1M33AVyIIyrgwmazqaioyNAxU1JSDB0PAAAAMIKvzq2NrpvvA7gQR1QAAAAAAADLIKgAAAAAAACWQVABAAAAAAAsg6ACAAAAAABYBkEFAAAAAACwDIIKAAAAAABgGQQVAAAAAADAMpptULF8+XKP79cbHx+vDz/8sGkKgt84deqU/vrXv+rtt9/W//zP/5hdDgAAuAyVlZX64IMP9Pbbb+uf//yn2eUAgCTJ4XDIbrdrzZo1Wrdunc6ePWt2SU3CUkFFdXW1MjMzFRUVpbCwMGVkZOjYsWOWGTs9PV35+fmG1OMr2rdvr5deesllmcPhUHh4uN5++22TqjLH2bNnlZmZqWuvvVa/+MUvNHz4cMXGxuqWW27R5s2bzS4PAAC44cyZM5o6daquvfZaDRkyRMOHD9f111+vlJQUbdu2zezy0Az42vz61KlTioqK0urVq53Lvv/+eyUmJmrEiBGqqakxsTr/8v7776tnz5666aablJGRoUGDBikmJkb//d//LYfDYXZ5XmWpoCInJ0f5+fkqKSnRgQMHJEljxoyxzNjp6ekqKCgwpB5fcPDgQR06dEh9+vRxWb5r1y6dPHlSffv2Naky4507d07Dhw/XggULdOrUKZfn/vGPfygpKUklJSUmVQcAANxx9uxZpaWlafHixaqqqnJ5bsOGDbrllltUWlpqUnVoDnxxfh0aGqoZM2Zo9uzZcjgcqq6u1qhRoxQSEqLXX39dgYGW+srps9566y0NGzZMX331lcvyo0ePasaMGXrkkUdMqqxpGL7VrFq1Sr169VJoaKgGDx6sadOmaeTIkZKkZcuWKSsrS926dVNERISefvppFRYWas+ePU1elztj9+nTR8HBwdqyZUuT1+ML7Ha7goKCFBsb67J827ZtateunTp27GhSZcbLy8vT+++/X+dzNTU1Onv2rB544AG/SzoBAPAnr732mtatW1fnczU1Nfr+++81adIkg6tCc+Kr8+vJkyfr0KFDWrNmjSZOnKgDBw4oPz9fISEhZpfmF77//ntNmDBBDofjkkeoLF682K++pxoaVKxYsULTp0/X0qVLVVFRobS0NC1ZskRxcXGqqKjQvn37FB8f71y/e/fuCg8P1/bt2z0aJycnR71793Z7fU/GHjZsGKd//C+73a4ePXqoZcuWLsu3bdtmybS3KS1durTetLimpkbbtm3TZ599ZmBVAADAE+58nm/atElffPGFgVWhOfHV+fVVV12lzMxM3XfffSoqKlJhYaHCw8PNLstvvPXWWyovL6/3j56BgYF64YUXDKyqaRkWVFRVVWnatGlatmyZkpKSFBQUpPHjx6u6ulpxcXGqrKyUJEVERLj8XGRkpPO53Nxc9e/fX/37979k2i1J2dnZHoUb7oxda8iQIZf8y3lzY7fbVVZWprZt27o85s+fr4SEBLPLM9T27dvdOv+OiQ0AANa1Y8cOPs9hKl+fX58+fVrZ2dlq166d2aX4lS+++EIBAQH1rlNTU+PxH/i9aerUqZo6dWqD67jNYZAPPvjAERkZ6bJsz549DkmOQ4cOOU6cOOGQ5Pj8889d1gkPD3fk5+c7Tpw44YiLi3OcOXPGcezYMUevXr0c586du+x6XnnlFUdycrLD4XA0OPb5li1b5rjrrrsue1x3STLlUdsTd7Ru3drx1FNPOfbv3+/yiIyMdLz33ntuv05ycrJp75cHDx48ePDgwYMHj6Z6eDK39tb82htza0/rfu211xytW7d2jBs3zhEbG+uoqanx6Of5PtB8Hu4KlkGOHDmia665xmXZypUrFR0drejoaElSp06dtHXrVtlsNkk/XTSmsrJSvXv3VklJiZKSkhQSEqKQkBB16dJF33zzjXr06NHo2iIjI+sd+3wFBQXKyMho9JgNcZhwLQNPbtdaVlamEydOKDU1VTExMS7Ly8vLPT40LTk5WUVFRR79jJWMGTNGK1eurPevMIGBgdq7d69LvwAAgHVkZGTonXfeqffz/IorrtDBgwcVFRVlYGXwRZ7MrSXvzq8bM7f2tO4PPvhAkyZN0nvvvaf4+Hh17dpVeXl5GjVqlEev4+vfB5pScXGxW7+XJ598Uk888UTTF1SH2vrq+x16sm0ZdupHbGysysrKVFxcrLNnz2rlypXKyclxBgOSNHHiRM2fP1+7d+9WZWWlsrKylJqaqi5duuj48eNq3bq1c93WrVvr+PHjXquvvrFrVVVVaf369UpLS/PauL7KbrerVatWF12ReOPGjerYsWOzO9xr8uTJ9U5qAgICNGLECEIKAAAsbMqUKQ1+nt9zzz2EFGgSvji/3rhxo0aPHq1XX31VAwYMcF6rYvbs2dyW1IsGDBig3r17X/IaOoGBgWrRooXGjx9vcGVNx7Cgom/fvnr88cc1fPhwxcTEqKSkRP369VNcXJxznezsbA0dOlQJCQnq0KGDqqurlZubK0lq06aNTpw44Vz3xIkTatOmTZ1jzZ0796Ir5TakvrFrrV27VnFxcWrbtq1Hr+2P7Ha7EhISFBzselDOpk2bLH2hn6bSr18/Pfvss5LksgOpPZesV69efnVxGwAA/FFKSoqefvppSXV/nsfHx2vx4sWm1Ab/52vz6x07digtLU0LFy7UXXfd5Vz+8MMP6+jRo8rLyzOxOv8SEBCg1atX1xlWBQYGKjg4WHl5ec4zFfxBgMOMcwz+V5cuXfTMM884b09an/Lyct12223atGmTTp8+reTkZJWWliooKOiyxl6+fLmWL1/u0eFF999/v2JjYzVjxozLGtPq3Dlcx5/GbQrFxcVavHix3n33XZ07d05du3bVQw89pAcffFBhYWFmlwcAANzw8ccfa/HixfrrX/+q6upq/exnP9OkSZP0wAMPqFWrVmaXBx/hq3NrM+r2p+8DTenbb7/Vn/70J/35z3/WkSNHJP30HXXq1Kke3fWyKbh76oe7v2PDrlFxocrKSu3du9fliIr6REZGaurUqc4GLFy48LJDisvVuXNnt0IVNF/JyclKTk6Ww+FQYGCgdu3aZXZJAADAQ4MGDdKgQYOcn+f/+te/zC4JABQdHa05c+Zozpw5OnfunK644gq9/PLLZpfVJEwLKnbs2KGwsDB1797d7Z+59957de+993plfJvNprFjx3r0M7NmzfLK2PB/Dd0+CAAAWB+f5wCs6sJThPyNae8uMTFRlZWVZg0vm83mciFPAAAAAABgPsMupgkAAAAAANAQggoAAAAAAGAZBBUAAAAAAMAyCCoAAAAAAIBlEFQAAAAAAADLIKgAAAAAAACW4d83X4XHSktLlZKSYviY3CoWAAAA/sZX59ZG1833AVyIoAJOZu0cbDYbOyYAAAD4FV+dW5tRN98HcKEAh8PhMLsIwB8FBASIf14AAPg2Ps8BWJWV9k+1R+AUFRXVu059z5+Pa1QAAAAAAADLIKgAAAAAAACWQVABAAAAAAAsg6ACAAAAAABYBkEFAAAAAACwDIIKAAAAAABgGQQVAAAAAADAMggqAAAAAACAZRBUAAAAAAAAyyCoAAAAAAAAlkFQAQAAAAAALIOgAgAAAAAAWAZBBQAAAAAAsIxgswuAdUydOlWlpaWmjG2z2bRo0SJTxgYAAAC8zVfn1mbVzfcBnI8jKuBUWlpqyk7JrHEBAACApuKrc2sz6ub7AC7EERVwYbPZVFRUZOiYKSkpho4HAAAAGMFX59ZG1833AVyIIyoAAAAAAIBlEFQAAAAAAADLIKgAAAAAAACWQVABAAAAAAAsg6ACAAAAAABYBkEFAAAAAACwjGYbVCxfvtzj2+DEx8frww8/bJqCAAAAAACAtYKK6upqZWZmKioqSmFhYcrIyNCxY8csM3Z6erry8/MNqcdXtG/fXi+99JLLMofDofDwcL399tsmVYXm4Msvv9SUKVP0H//xH+rSpYuGDx+ujz76SA6Hw+zSAKBJHDhwQL///e91ww03qFOnTrr99tu1atUq/fjjj2aXBsCLfG1+ferUKUVFRWn16tXOZd9//70SExM1YsQI1dTUmFidfzlz5oxWrFihpKQkderUSZI0b948HTlyxOTKvM9SQUVOTo7y8/NVUlKiAwcOSJLGjBljmbHT09NVUFBgSD2+4ODBgzp06JD69OnjsnzXrl06efKk+vbta1Jl8Hcvv/yyevbsqeeee05lZWXau3ev8vPzNXjwYI0bN44PRAB+Z926dbruuuv05JNP6ssvv9T+/fv1t7/9TXfffbcGDx6s06dPm10iAC/wxfl1aGioZsyYodmzZ8vhcKi6ulqjRo1SSEiIXn/9dQUGWuorp886duyY+vfvr7Fjx2rjxo3av3+/JGnmzJn6+c9/ri1btphcoXcZvtWsWrVKvXr1UmhoqAYPHqxp06Zp5MiRkqRly5YpKytL3bp1U0REhJ5++mkVFhZqz549TV6XO2P36dNHwcHBfrcRXC673a6goCDFxsa6LN+2bZvatWunjh07mlQZ/Nmnn36qCRMmqKamxuXoidpwYvny5Zo3b55Z5QGA1+3fv1/Dhg3TmTNnXJbX7veKior04IMPmlEaAC/z1fn15MmTdejQIa1Zs0YTJ07UgQMHlJ+fr5CQELNL8xujR4/Wtm3bJOmiP8qVl5crNTVVFRUVZpTWJAwNKlasWKHp06dr6dKlqqioUFpampYsWaK4uDhVVFRo3759io+Pd67fvXt3hYeHa/v27R6Nk5OTo969e7u9vidjDxs2jNM//pfdblePHj3UsmVLl+Xbtm2zZNoL//DHP/7RrXV++OEHA6oBgKb34osvqqqqqt6jxVauXOk8IhSA7/LV+fVVV12lzMxM3XfffSoqKlJhYaHCw8PNLstvlJaWat26dZc8xbmmpkbHjx/Xa6+9ZnBlTcewoKKqqkrTpk3TsmXLlJSUpKCgII0fP17V1dWKi4tTZWWlJCkiIsLl5yIjI53PDRo0SG3bttWcOXPqHSs7O9ujcMOdsWsNGTJE77//vtuv7c/sdrvKysrUtm1bl8f8+fOVkJBgdnnwQzU1NXrnnXcaPLXj+PHj2rhxo0FVAUDTeuuttxpcp6amRu+++64B1QBoSr4+vz59+rSys7PVrl07s0vxK++8806D6wQEBGjNmjUGVGOMYKMGKi4uVk1Nje68807nsqNHj0qS4uLi1KJFC0m66HCV8vJyZxq3fPlyffzxx17/i0FYWFiDY9fau3ev88IlTSkgIKDJx6hLcnKy2+tu3rxZs2bN0r333uuyvFevXh4nvsXFxaa956bkj+/JV9x2221mlwAAhpo0aZImTZpkdhl+ic9zXC5P5taS9+bXjZ1be1p3bm6u5s2bp3Hjxmnx4sUaP368x+P76/cBozgcDq1fv970HnprfMOCiiNHjuiaa65xWbZy5UpFR0crOjpaktSpUydt3bpVNptN0k8XjamsrHSexhETE9MktUVGRjY4dq2CggJlZGQ0SR3nM+POBZ7crrWsrEwnTpxQamqqy++lrKxM5eXlHgcVycnJKioq8uhnrC4gIIA7UHiZw+FQdHS0W1c23rlzp2644QYDqgKApjVw4ED9/e9/b/BostWrV2v48OEGVdV88HmOy+XJ3Fry7vy6MXNrT+v+4IMPNGnSJL333nuKj49X165dlZeXp1GjRnn0Ov74fcBbnn/++QaD6MDAQI0aNUpvvPGGQVW5qt1u6vsderJtGXbqR2xsrMrKylRcXKyzZ89q5cqVysnJcQYDkjRx4kTNnz9fu3fvVmVlpbKyspSamqouXbo0eX3ujF1VVaX169crLS2tyeuxOrvdrlatWl10ReKNGzeqY8eOHO6FJhEQEKAHHnig3nUCAwPVv39/QgoAfqP2AsKXEhAQoKioKOYngI/zxfn1xo0bNXr0aL366qsaMGCA81oVs2fP5i5sXvTLX/7SeQbCpdTU1GjChAkGVdT0DAsq+vbtq8cff1zDhw9XTEyMSkpK1K9fP8XFxTnXyc7O1tChQ5WQkKAOHTqourpaubm5Ho81d+7ci66U2xB3xl67dq3i4uLUtm1bj2vyN3a7XQkJCQoOdj0oZ9OmTZa+0A98329/+1t16dKlzltdBQYGKjg4WAsWLDChMgBoGiNGjNAtt9xS5+G0tX/t/+Mf/6grr7zShOoAeIuvza937NihtLQ0LVy4UHfddZdz+cMPP6yjR48qLy/PxOr8S2RkpJ566ql610lPT9fAgQMNqqjpGXbqhyTNnj1bs2fPdv5/ly5dXFKfoKAgLViwoNFfMmbOnKmZM2d69DPujF1QUKD09PRG1eYvFi5cWOfy559/3uBK0Ny0bdtWGzZs0JgxYy46tKxTp0565ZVXlJiYaE5xANAErrzySv31r3/VhAkTlJeX5/JXyquvvlqLFi3SPffcY2KFALzB1+bXPXv21HfffXfR8latWunw4cMmVOTfpk2bpiuuuEJPPPGEyw0fgoKC9Jvf/EZLliwx/foU3mTo7UnPV1lZqb1797ocUdGQcePG6ZlnntHy5cs1dOjQJqyubp07d9bIkSMNHxeAq5iYGK1fv17bt293fqgXFhbqm2++8fi8SgDwBWFhYXrzzTe1a9cuPfvss5KkvLw8/fvf/9avf/1rk6sDABhhypQpOnTokF5//XXNmzdPknTgwAG9+OKLCgkJMbk67zL0iIrz7dixQ2FhYerevbvbP/Pyyy97bXybzaaxY8d69DOzZs3y2vgAGq9Xr17q1auXpk2bptTUVLPLAYAm17lzZ02ePFlTpkzRiBEjzC4HAGCwVq1a6Ve/+pUk6bHHHnPemMLfmBZUJCYmuhyyYjSbzeZyIU8AAAAAAGA+0079AAAAAAAAuBBBBQAAAAAAsAyCCgAAAAAAYBkEFQAAAAAAwDIIKgAAAAAAgGUQVAAAAAAAAMsw7faksKbS0lKlpKQYPia3igUAAIC/8dW5tdF1830AFyKogJNZOwebzcaOCQAAAH7FV+fWZtTN9wFcKMDhcDjMLgLwRwEBAeKflzHoNYDmhv2eceg1AKuy0v6p9gicoqKietep7/nzcY0KAAAAAABgGQQVAAAAAADAMggqAAAAAACAZRBUAAAAAAAAyyCoAAAAAAAAlkFQAQAAAAAALIOgAgAAAAAAWAZBBQAAAAAAsAyCCgAAAAAAYBkEFQAAAAAAwDIIKgAAAAAAgGUQVAAAAAAAAMsgqAAAAAAAAJYRbHYBsI6pU6eqtLTUlLFtNpsWLVpkytgAAACAt/nq3Nqsuvk+gPNxRAWcSktLTdkpmTUuAAAA0FR8dW5tRt18H8CFOKICLmw2m4qKigwdMyUlxdDxAAAAACP46tza6Lr5PoALcUQFAAAAAACwDIIKAAAAAABgGQQVAAAAAADAMggqAAAAAACAZRBUAAAAAAAAyyCoAAAAAAAAltFsg4rly5d7fBuc+Ph4ffjhh01TEAAAAAAAsFZQUV1drczMTEVFRSksLEwZGRk6duyYZcZOT09Xfn6+IfX4ivbt2+ull15yWeZwOBQeHq63337bpKoAeNvOnTv14osv6oUXXtDnn39udjmwmPLycuXm5uq5555TQUGBzp49a3ZJAOCzfG1+ferUKUVFRWn16tXOZd9//70SExM1YsQI1dTUmFgdfJWlgoqcnBzl5+erpKREBw4ckCSNGTPGMmOnp6eroKDAkHp8wcGDB3Xo0CH16dPHZfmuXbt08uRJ9e3b16TKAHjL7t27NXDgQPXs2VMPPvigHnroId144426+eab9eWXX5pdHkx27tw5ZWZm6tprr9WYMWM0efJkpaenKyYmRi+//LLZ5QGAz/HF+XVoaKhmzJih2bNny+FwqLq6WqNGjVJISIhef/11BQZa6isnfIThW82qVavUq1cvhYaGavDgwZo2bZpGjhwpSVq2bJmysrLUrVs3RURE6Omnn1ZhYaH27NnT5HW5M3afPn0UHBysLVu2NHk9vsButysoKEixsbEuy7dt26Z27dqpY8eOJlUGwBsOHjyoxMRE/f3vf7/oObvdrltuuUVlZWUmVAYrcDgcuv/++7VgwQKdOXPG5bmjR4/qN7/5jZ5//nmTqgMA3+Sr8+vJkyfr0KFDWrNmjSZOnKgDBw4oPz9fISEhZpcGH2VoULFixQpNnz5dS5cuVUVFhdLS0rRkyRLFxcWpoqJC+/btU3x8vHP97t27Kzw8XNu3b/donJycHPXu3dvt9T0Ze9iwYZz+8b/sdrt69Oihli1buizftm2bJdNeAJ556qmndPjw4ToP2aypqVFFRYV+//vfm1AZrGDjxo3Kzc2td50ZM2aosrLSoIoAwPf56vz6qquuUmZmpu677z4VFRWpsLBQ4eHhZpcFH2ZYUFFVVaVp06Zp2bJlSkpKUlBQkMaPH6/q6mrFxcU5JzIREREuPxcZGanKykpt2bJFt9xyiwYMGKDbbrtNu3btuuRY2dnZHoUbDY19viFDhuj99993+7X9md1uV1lZmdq2bevymD9/vhISEswuD0AjfP/991qxYoUcDscl16mpqVFeXp6OHz9uYGWwimXLljV4OG9VVZXeeOMNgyoCAN/n6/Pr06dPKzs7W+3atTO7FPi4YKMGKi4uVk1Nje68807nsqNHj0qS4uLi1KJFC0k/Hd1wvvLycoWHh6t9+/YqLCxUWFiYPvjgA/3hD3/Qa6+95pXawsLC6h37fHv37lWnTp28Mq6v27x5s2bNmqV7773XZXmvXr0snfgCaNi3336rqqqqBtc7d+6c9u7dqzZt2hhQFazkn//8Z4MXSAsMDNTXX39tUEUA4Pt8dX6dm5urefPmady4cVq8eLHGjx+vgIAAs8uCDzMsqDhy5IiuueYal2UrV65UdHS0oqOjJUmdOnXS1q1bZbPZJP100ZjKykr17t1b1157rfPnrrzySgUHe6/0yMjIesc+X0FBgTIyMrw29qWY9Q87OTnZrfXKysp04sQJpaamKiYmxmV5eXm5xzvS4uJiv9yZ+eN7sip6bZ7zT5sDzldTU6OFCxdq4cKFZpfil9jvGYde43K5O7eWvDu/buzc2pO6P/jgA02aNEnvvfee4uPj1bVrV+Xl5WnUqFEejemv3weamtV65q16DAsqYmNjVVZWpuLiYvXv319vvfWWcnJylJiY6Fxn4sSJmj9/vgYOHKg2bdooKytLqamp6tKli3Od2sOJVqxY4dX63Bm7qqpK69ev1yuvvOLVsetS3+HWTSUlJcXtde12u1q1anXRFYk3btyojh07eny4V3JysoqKijz6GasLCAgw5ffYHNHrphEfH6/S0tJL/tU8ICBAXbt21b/+9S+u6N0MLVq0SI888kiD63322Wc+cbiyr2G/Zxx6jcvlydxa8u78ujFza0/q3rhxo0aPHq1XX31VAwYMkCRlZmZq9uzZGjFihEfzA3/8PtDUrLR/qt1u6vsderJtGTaz7Nu3rx5//HENHz5cMTExKikpUb9+/RQXF+dcJzs7W0OHDlVCQoI6dOig6upqlwt1nT17ViNHjtQTTzxx0ZVwzzd37tx6n69LQ2NL0tq1axUXF6e2bdt69Nr+yG63KyEh4aIjWzZt2mTpw9IAuG/GjBn1HtrvcDg0Y8YMQopm6r777lNkZOQlf/+BgYFKTEwkpAAAN/na/HrHjh1KS0vTwoULdddddzmXP/zwwzp69Kjy8vJMrA6+LsBhYgTTpUsXPfPMM87bk9anurpad999t+644w6NHz++0WMvX75cy5cv9yi1u//++xUbG6sZM2Y0enwrcicF86dxm5qVEk5/R6+bzhNPPKGnnnpKgYGBztCi9r8ffvhhPfvss5Y75BDG2bhxo+68806XC0/Xbh/XXXed1q9f73LqJryH/Z5x6DUul6/Orc2o21+/DzQ1K+2f3D2iwt3fsWl/BqusrNTevXtdjqioT15engoLC5Wbm6uUlBRNmTKliSu8WOfOnd0KVQDAX8yZM0dFRUXKyMhwXmdoyJAhKiwsJKSAEhMTtXPnTj3++OPq2rWrpJ8u+Pbss8/KbrcTUgAAgMti2DUqLrRjxw6FhYWpe/fubq0/evRojR492mvj22w2jR071qOfmTVrltfGBwBfkZyc7LyoVkBAgAoKCkyuCFYSExOjOXPmaM6cOQoICFBpaanZJQEAAB9nWlCRmJjocqio0Ww2m/MOHwAAAAAAwBq4AhoAAAAAALAMggoAAAAAAGAZBBUAAAAAAMAyCCoAAAAAAIBlEFQAAAAAAADLIKgAAAAAAACWQVABAAAAAAAsI9jsAmAtpaWlSklJMXxMm81m6JgAAABAU/PVubXRdfN9ABciqIBRHbaYAAAgAElEQVSTWTsHm83GjgkAAAB+xVfn1mbUzfcBXCjA4XA4zC4C8EcBAQHin5cx6LVx6DXqw/ZhHHptHHoNwKqstH+qPQKnqKio3nXqe/58XKMCAAAAAABYBkEFAAAAAACwDIIKAAAAAABgGQQVAAAAAADAMggqAAAAAACAZRBUAAAAAAAAyyCoAAAAAAAAlkFQAQAAAAAALIOgAgAAAAAAWAZBBQAAAAAAsAyCCgAAAAAAYBkEFQAAAAAAwDIIKgAAAAAAgGUQVAAAAAAAAMsgqAAAAAAAAJZBUAEAAAAAACyDoAIAAAAAAFhGsNkFAAAAAACASzt8+LDeeOMNlZSUaPv27Tp58qSCgoKUlpamvn37auTIkYqNjTW7TK/hiAoAAAAAACzo8OHDuu+++9SxY0c98sgj+vTTT/Wzn/1Mt912m6qrq7V79249+eST6tmzpwYOHKjPP//c7JK9gqACAAAAAACLyc/P1w033KA333xTDz30kL788kvt27dP+fn5Wr58uSRp586d+vbbbzV//nx99dVXuummm/Tkk0/K4XCYW3wjEVQAAAAAAGAhubm5Gj58uLp27arPP/9cixcv1vXXX1/nulFRUXr00Ue1c+dOjRo1Sr///e/18MMP+3RYwTUqAAAAAACwiJKSEo0dO1YpKSl699131apVK7d+7uqrr1Zubq46dOigZ555Rj169NDUqVObuNqm0WyPqFi+fLlSUlI8+pn4+Hh9+OGHTVMQAAAAAKBZO3PmjMaOHav27dtrzZo1bocUtQICAjR//nwNHTpUjz32mL7++usmqrRpWSqoyMrKUmxsrMLDw9W+fXtNmDBB3333nSFjV1dXKzMzU1FRUQoLC1NGRoaOHTvmsk56erry8/MNqQcAAAAA0LysWLFCX331lZYtW6aIiIjLeo2AgAC98MILuuKKKzR79mwvV2gMSwUVQUFBys3N1fHjx7Vt2zYdOHBA999/vyFj5+TkKD8/XyUlJTpw4IAkacyYMS7rpKenq6CgwJB6AAAAAADNh8Ph0NKlS2Wz2ZSamtqo12rfvr3Gjh2rvLw8HTlyxEsVGsfwoGLVqlXq1auXQkNDNXjwYE2bNk0jR46UJM2dO1dxcXG64oorFBUVpcmTJ6uoqMiQupYtW6asrCx169ZNERERevrpp1VYWKg9e/Y41+nTp4+Cg4O1ZcsWQ2oCAAAAADQP+/fv1/bt2zV27FgFBAQ0+vXGjh2rs2fP6qOPPvJCdcYyNKhYsWKFpk+frqVLl6qiokJpaWlasmSJ4uLi6lx/3bp16t27t8fj5OTkePRzFRUV2rdvn+Lj453LunfvrvDwcG3fvt1l3WHDhnH6BwAAAADAq2r/IH7zzTd75fV69+6tli1b+uQf2g0LKqqqqjRt2jQtW7ZMSUlJCgoK0vjx41VdXV1nULF69Wr9+c9/1uLFi53LcnNz1b9/f/Xv31/r1q275FjZ2dkXBQz1qayslKSLzgGKjIx0PldryJAhev/9991+bQAAAAAAGrJ7925J0nXXXeeV1wsODtbPfvYz7dq1yyuvZyTDbk9aXFysmpoa3Xnnnc5lR48elaSLgoq8vDw98MADKigo0I033ihJKi8v18KFC7Vp0yadOnVKAwcO1Oeff66goKBG1xYWFibppyMrzldeXq7w8HCXZXv37lWnTp0aPWZDvHGoD8zH79E49No49Br1YfswDr02Dr0GYKTWrVu7va47+6cvvvjCsP2Yt8YxLKg4cuSIrrnmGpdlK1euVHR0tKKjo53LXnnlFU2fPl3vvvuubrnlFufykpISJSUlKSQkRCEhIerSpYu++eYb9ejRo9G1RUZGqlOnTtq6datsNpskadeuXaqsrLzoFJKCggJlZGQ0esyGOByOJh8DTSsgIIDfo0HotXHoNerD9mEcem0ceg3AKC+99JLGjx+vsrIyde/evcH13dk/dejQQYMGDdKKFSu8VWadUlJSJKnea0zWruMOw079iI2NVVlZmYqLi3X27FmtXLlSOTk5zmBAkpYsWaIZM2Zo7dq1LiGFJB0/ftwlWWrdurWOHz/utfomTpyo+fPna/fu3aqsrFRWVpZSU1PVpUsX5zpVVVVav3690tLSvDYuAAAAAAC1Zxp465oS3377rf79739f8pqQVmZYUNG3b189/vjjGj58uGJiYlRSUqJ+/fq5NO13v/udKisrNXDgQIWGhjofktSmTRudOHHCue6JEyfUpk2bOseaO3euYmNjPaovOztbQ4cOVUJCgjp06KDq6mrl5ua6rLN27VrFxcWpbdu2Hr02AAAAAAD16dmzp8LDw1VQUOCV16u9CcStt97qldczkqF3/Zg9e7aOHz+uI0eOaPHixfr6669dggqHw6Eff/xRp06dcnlIUr9+/bRhwwb98MMP+u6777R79+5LHg4zc+ZM7dy506PagoKCtGDBAh07dkwnT57UmjVrLgokCgoKlJ6e7uG7BgAAAACgfldeeaXGjh2rvLw8ffvtt416rZqaGj333HOKi4tzubulrzA0qDhfZWWl9u7d6/ZhKJGRkZo6dapSUlI0ZMgQLVy40CsX0vRE586dNXLkSEPHBAAAAAA0D5MnT5YkTZkypVGv86c//UlffPGFpk+f7pMXBA5wmHR1oI0bN+qOO+5QRUWFKY0rLS1VaWmpxo4da/jYaB64+JZx6LVx6DXqw/ZhHHptHHoNwGjz5s3TzJkz9cILL+iBBx645HqX2j9t3rxZAwYM0MCBA/Xee+8Z8n3b3Ytp1vf8+Qy768eFEhMTVVlZadbwstlsLhfyBAAAAADAbJmZmdqwYYMeeughnTlzRr/97W/dDhuKior0X//1X2rXrp3+8pe/+OTRFJKJp34AAAAAAABXwcHBWr16tdLS0jR16lSlpqY2eA3Gw4cP67e//a0GDhyoa665RuvXr9e1115rUMXeZ9oRFQAAAAAA4GItW7bUO++8oxdffFGZmZnq2bOnkpOTNXjwYMXFxal169aSpCVLlmjDhg3Kz8/Xjz/+qClTpmjevHm66qqrTH4HjWPaNSoAf8c5rcah18ah16gP24dx6LVx6DUAsx09elSvvPKKXnnlFX311VcXPR8dHa27775bDz74oK6//noTKvSja1QAAAAAAID6RUVF6dFHH9Wjjz6qiooKffHFFzp58qR+8Ytf6ODBg2rfvr3ZJXodQQUAAAAAAD4gIiJCt956qyT59dFeXEwTAAAAAABYBkEFAAAAAACwDIIKAAAAAABgGQQVAAAAAADAMggqAAAAAACAZRBUAAAAAAAAyyCoAAAAAAAAlkFQAQAAAAAALIOgAgAAAAAAWAZBBQAAAAAAsAyCCgAAAAAAYBkEFQAAAAAAwDIIKgAAAAAAgGUQVAAAAAAAAMsgqAAAAAAAAJZBUAEAAAAAACyDoAIAAAAAAFhGsNkFwDqmTp2q0tJSU8a22WxatGiRW+uaWaenUlJSzC6hQfX1nl57T0PbOL32Hl/Zn/hKnZ6y+vYhsd8zEr02ji/sUzyp0R/4ymcMzMO/xUvjiAo4lZaWmvIPxdNxzarTU8nJyWaX0KCGekmvvcOdPtJr7/CV/Ymv1Okpq28fEvs9I9Fr4/jCPsVXft/e5CufMTAP/xYvjSMq4MJms6moqMjQMS/nrxRm1OmP3Ok9vW48d7dxet14vrI/8ZU6/RH7PePQa+P4wj7FF45KaQq+8hkD8/BvsW4cUQEAAAAAACyDoAIAAAAAAFgGQQUuS/v27dWyZUuFhoYqIiJCd9xxh/bv3292WaY4cuSIAgICLjrXa+/evQoICNCXX35pUmX+h14bh16jPmwfxqHXxqHXF2O+B8AsBBXw2MGDB3Xo0CFt3bpVp06d0q5du3TkyBFlZ2ebXZop7Ha7WrRooZ49e7os/+yzzxQWFqbrrrvOpMr8D702Dr1Gfdg+jEOvjUOvXTHfA2Amggp4zG63Kzw8XNdff70kqU2bNrrxxht1+PBhkyszx+bNmxUXF6fgYNdr03722WeKj49XYCD/zLyFXhuHXqM+bB/GodfGodeumO8BMFPz2uPCK+x2uxISEhQQEKBz586psLBQ/+///T/96le/Mrs0U2zevFkJCQkXLf/ss8/qXI7LR6+NQ69RH7YP49Br49BrV8z3AJip2QYVy5cv9/jWLPHx8frwww+bpiAfYrfb9cknnygyMlItWrTQqFGj9NJLL2ncuHFml2aKLVu2XDSBqamp0datW5WQkKBjx46pf//+Sk5OVkJCgj766COTKvV99No49Br1YfswDr02Dr12xXwPgJksFVS8+eabSkpKUnh4+EWH3TW16upqZWZmKioqSmFhYcrIyNCxY8dc1klPT1d+fr6hdVnR5s2b9cYbb6i8vFz79+9XTEyMvvrqK7PLMkXt+Zvx8fEuy0tLS3Xq1CndfPPNat26tT755BMVFxfrjTfe0MyZM02q1rfRa+PQ60t75ZVXFBoaetEjKChIQUFBOnXqlNklNjm2D+PQa+PQ64sx3zPeqVOnFBUVpdWrVzuXff/990pMTNSIESNUU1NjYnWwivbt2+ull15yWeZwOBQeHq63337bpKq8z1JBRevWrTVp0iQtWrTI8LFzcnKUn5+vkpISHThwQJI0ZswYl3XS09NVUFBgeG1WUlZWphMnTujGG2+UJF177bWaPn26XnjhBefO85NPPnFJ2++++25t2bLFlHqbWu22EhkZ6bJ85cqVuvnmm9WxY0fnFxhJOnnypPr06WN4nf6AXhuHXl/a/fffr1OnTrk8Xn75ZV1xxRX6y1/+otDQULNLbHJsH8ah18ah166Y75kjNDRUM2bM0OzZs+VwOFRdXa1Ro0YpJCREr7/+erO7TgouVhuqXrj/2bVrl06ePKm+ffuaVJn3Gb61r1q1Sr169VJoaKgGDx6sadOmaeTIkZKk1NRU/fKXv1S3bt2MLkvLli1TVlaWunXrpoiICD399NMqLCzUnj17nOv06dNHwcHBzXonbLfbdfXVV6tz587OZenp6Tp8+LA++eQTSVLfvn31+eefS5LWr1+viIiIi/5C4S9+/vOfKyIiQjk5OSovL9d3332nF154QUuXLlVOTo5zvd27d+vWW2/V4MGDddddd5lYse+i18ah1+577bXXdO+99+qll17S/fffb3Y5hmD7MA69Ng69dsV8zzyTJ0/WoUOHtGbNGk2cOFEHDhxQfn6+QkJCzC4NFmC32xUUFKTY2FiX5du2bVO7du3UsWNHkyrzPkODihUrVmj69OlaunSpKioqlJaWpiVLliguLs6r4+Tk5Kh3795ur19RUaF9+/a57Fy7d++u8PBwbd++3WXdYcOGNevTP+x2+0W/r7Zt2yoxMVFvvfWWJKlFixZq0aKFTpw4oT/84Q966qmnzCjVEOHh4Xrvvfe0efNmxcTE6Prrr9eaNWtUWFio5ORk53pdu3bVJ598IrvdrsmTJ5tYse+i18ah1+7585//rAkTJuj111/XPffcY3Y5hmH7MA69Ng69dsV8zzxXXXWVMjMzdd9996moqEiFhYUKDw83uyxYhN1uV48ePdSyZUuX5du2bfOroykkybALQVRVVWnatGnKzc1VUlKSJGn8+PH63e9+53ZQkZubq+eee06SNGfOHP3nf/5nnetlZ2d7dI/nyspKSVJERITL8sjISOdztYYMGaLHHntMs2fPdvv1/cnChQvrXL5hwwaX/+/Xr58mTJigjIwMRUVFGVGaaW699VZ9+umnl3z+hx9+cKbg4eHhCgsLM6o0v0OvjUOv6/fss8/q0UcfVV5enoYOHWp2OYZj+zAOvTYOvf4/zPfMd/r0aWVnZ6tdu3ZmlwILsdvtKisrU9u2bV2Wnzp1So899phJVTUNw4KK4uJi1dTU6M4773QuO3r0qCS5FVSUl5dr4cKF2rRpk06dOqWBAwfq888/d54r2Bi1HzQVFRUXjXlhgrl371516tSp0WP6u5tvvllPPvmk3nzzTbNLMd3WrVuVlZWloKAgnTt3zpRrsDQX9No4zbnXzzzzjP7whz8oPz9fgwcPNrscS2rO24fR6LVx6PXFmO95X25urubNm6dx48Zp8eLFGj9+vAICAswuCxaxefNmzZo1S/fee6/L8l69enFExeU6cuSIrrnmGpdlK1euVHR0tKKjoxv8+ZKSEiUlJSkkJEQhISHq0qWLvvnmG/Xo0aPRtUVGRqpTp07aunWrbDabpJ8uSFJZWXnRKSQFBQXKyMho9JgNMWuHdP7hjY3xySefaMmSJW7fvaW4uNij9+ytOo3Qv39//f3vfze7jEtqqPf02jvc2cbptXc05f7kySef1Pz58/X+++9r4MCBl1OeE/s987DfMw69No4Z+5Smnu/5A0/6/MEHH2jSpEl67733FB8fr65duyovL0+jRo3yeNzm2Gtf5e42UnuR29TUVMXExLgsLy8v9yioaMrtw1uva9g1KmJjY1VWVqbi4mKdPXtWK1euVE5OjjMYkH66ReiZM2d09uxZSdKZM2d05swZORwOHT9+XK1bt3au27p1ax0/ftxr9U2cOFHz58/X7t27VVlZqaysLKWmpqpLly7OdaqqqrR+/XqlpaV5bdxLcTgchj+88YF14MABpaenKyIi4pKn5tQlOTnZ0Drxf+rrPb32noa2cXrtPU21P5k5c6YWLFigtWvXNjqkaMo60TD2e8ah18Yxcp9ixHzPHx6e9Hnjxo0aPXq0Xn31VQ0YMMB5rYrZs2df1m1Jm1uvffXhyTZit9vVqlWri+74sXHjRnXs2NGj04SaYvtITk726nzXsKCib9++evzxxzV8+HDFxMSopKRE/fr1cznt47XXXlPLli2Vmpqq6upqtWzZUi1bttTevXvVpk0bnThxwrnuiRMn1KZNmzrHmjt37kVXQm1Idna2hg4dqoSEBHXo0EHV1dXKzc11WWft2rWKi4u76Jwg/J+YmBjl5+dzQSUAfqW0tFTz5s1TVVWVUlNTFRoa6vLwt/NCAaA+zPe8a8eOHUpLS9PChQtd7ibz8MMP6+jRo8rLyzOxOliF3W5XQkLCRUcwbdq0ye9O+5AMPPVDkmbPnu1yEcouXbpowoQJzv8fO3asxo4dW+fPRkZG6rHHHtMPP/yg06dPa/fu3erevXud686cOVMzZ870qLagoCAtWLBACxYsuOQ6BQUFSk9P9+h1AQC+z2azyeFwmF0GAMAP9ezZU999991Fy1u1aqXDhw+bUBGs6FIXuX3++ecNrsQYhgYV56usrNTevXvdvuNHZGSkpk6dqpSUFEk//aK8cSFNT3Tu3FkjR440dEwAAAAAAJoTw079uNCOHTsUFhZ2yaMi6nLvvfdq06ZN2rRpk26//fZGjW+z2S559MalzJo1S507d27UuP7k4MGDmjp1qvP/Fy5cqFtvvdX5/4888oiSkpL0u9/9zozyvKb2fZaUlCgxMVFJSUl65JFHnM+7+z69vZ4/qu31v//9b914441q0aKFzp0753yeXjeN2r7v2bNH7dq1U0pKSoN3s6DHzRfbS9NiP2gcPt8vT3OZ/wEwl2lBRWJioiorK027Gu3lBBVw9dFHHzkDox9++EHbtm1zPrd161adPn1aGzZs0NmzZ2W3280qs9Fq32fnzp31t7/9TRs2bNCRI0f0xRdfuP0+vb2ev6rt9dVXX61169bp5ptvdj5Hr5vO+f+Wb7/9dhUVFenDDz+85Pr0uHlje2la7AeNw+f75Wku8z8A5jItqIBvKSoqUuvWrZWSkqLOnTvrrrvuUlFRkfPKrX/5y1903333OdfftGmTBg0aJEkaNGiQ/vGPf5hSt6fqe5/R0dFq0aKFJCk4OFhBQUFuv09vr+cP6ut1ixYtXO7yI3m/h82p1+dr6N/y+vXrlZSUpD/+8Y+XfA163DzUta3ULmd7abyG+st+0Hsa6jWf73VzZx/gL/M/ANZDUAG3DBgwQDfddJPzw+m5555TVVWVQkND9eOPP6q4uFi33Xabc/3y8nKFh4dLkiIiIlzu2GJl9b3PWtu3b9exY8d0ww03uP0+vb2eP3Cn1+ej195RX9+vvfZaff3111q/fr0+/vhjbd++vc7XoMfNQ13bisPhYHvxkob6Wxf2g5fH3V7z+e6qob750/wPgPWYdjFN+JZdu3apW7dukqT9+/fr6NGjznv4vvbaa/rVr37lsn5kZKQqKysl/XTh1MjISGMLvkz1vU9J+u677zR58mStWrVKkvvv09vr+YOGen0heu0d9fU9JCREISEhkqS0tDTt2LFDvXv3vug16LF/+fbbbzV69GiXZdHR0ZozZ47LttKhQweVlpayvXjocvtbF/aD9WtMr5vz5/vl9s2f5n8ArIcjKuCWnTt3KjY2VtXV1QoMDNSHH37oPD/xn//8p55//nndcccd2rlzp5599ln1799f69atkyR9/PHHLufYWll97/PcuXP69a9/rWeeeUbR0dGSVOf7PHfu3EW3kmrMev6qvl7XhV57R319P3nypHO9Tz/9VN27d6fHzUB0dLSKiopcHm+++eZF24oktpfLcLn9rQv7wfpdbq+b++f75fbNn+Z/AKyHoAJuqf2w+uGHH3TkyBGtW7dOffv2lSTNnz9fa9euVWFhoWJjYzVlyhTnlcqTkpIUGBiom266yeR34J763mdeXp7sdruysrKUkpKiTZs21fk+9+zZoyeeeMLldRuznr+qr9c//vijBg0apG3btik1NVUlJSX02kvq6/uGDRsUHx+vxMREtW/fXv369aPHzdiF28qhQ4e0ZcsWthcvaai/7Ae9p6Fe8/let4b65k/zPwDWE+BwOBxmFwFrSElJkfTTRZIasmrVKo0aNcrwcS9n/ca4nPe5evVqtW7d2uWczcas15Qa6iW99g53+mhkr8/XUN99pce1rLw/acy4ZtV5IX/YXqy037uQv+0H6bV1et3Y9Ws1Zv5nlf2YkXzlMwbmMeN31VRjujvfdXdcggo4paSkqLS0VDabzdBxa8f05MPVjDr9UUO9p9fe4c42Tq+9w1f2J75Spz9iv2ccem0cX9ineFqjP/CVzxiYx5/+LXo7qOBimnAya6Jgs9k8GpsJjfc01Ht67R3ubOP02jt8ZX/iK3X6I/Z7xqHXxvGFfYqnNfoDX/mMgXn4t3hpHFEBAAAAAAAum7ePqOBimgAAAAAAwDIIKgAAAAAAgGUQVAAAAAAAAMsgqAAAAAAAAJZBUAEAAAAAACyDoAIAAAAAAFgGQQUAAAAAALAMggoAAAAAAGAZBBUAAAAAAMAyCCoAAAAAAIBlEFQAAAAAAADLIKgAAAAAAACWQVABAAAAAAAsg6ACAAAAAABYBkEFAAAAAACwDIIKAAAAAABgGQQVAAAAAADAMggqAAAAAACAZRBUAAAAAAAAyyCoAAAAAAAAlkFQAQAAAAAALIOgAgAAAAAAWAZBBQAAAAAAsAyCCgAAAAAAYBk+GVRUV1crMzNTUVFRCgsLU0ZGho4dO+ZzYwAAAAAAAFc+GVTk5OQoPz9fJSUlOnDggCRpzJgxPjcGAAAAAABwZemg4tNPP1VqaqratWunyMhIjRw5UpK0bNkyZWVlqVu3boqIiNDTTz+twsJC7dmzx2tjGzEGAAAAAABwZdmgYvXq1Ro2bJgmTpyoffv2af/+/Ro/frwqKiq0b98+xcfHO9ft3r27wsPDtX379jpfKycnR71793Z77MsZAwAAAAAANF6w2QXU5fTp03rggQe0ePFiZWRkSJJCQkKUmpqq/fv3S5IiIiJcfiYyMlKVlZV1vl52drays7PdHr/2dTwZw9uy5y8zZBwAAAAAABpj175Dkur/Hlu7jjssGVQUFxcrICBA99xzz0XPhYWFSfrpqIfzlZeXKzw83CvjGzFGQ3KyJhoyDgAAAAAAjXHm0P9Iqv97bO067rBkUHHs2DG1bt1aAQEBFz0XGRmpTp06aevWrbLZbJKkXbt2qbKy0qPTO+pjxBgAAAAAAPiDRYsWeWWdWgEOh8PRmIKaws6dO2Wz2bRmzRoNGTJElZWVKikpUWpqqiTpqaee0quvvqrCwkK1adNGv/nNb3Ty5EkVFhZ6rQYjxqgPp34AAAAAAPyJu2cOWDKokKQVK1Zo7ty5OnjwoMLCwjRu3Dg99dRTkqTq6mplZWVp+fLl+uGHH3T77bdr2bJlatu2bZ2vNXfuXL3++uvauXOn2+N7OgYAAAAAAGg8ywYVAAAAAACg+bHs7UkBAAAAAEDzQ1ABAAAAAAAsg6ACAAAAAABYBkEFAAAAAACwDIIKAAAAAABgGQQVAAAAAADAMggqAAAAAACAZRBUAAAAAAAAyyCoAAAAAAAAlkFQAQAAAAAALIOgAgAAAAAAWAZBBQAAAAAAsAyCCgAAAAAAYBkEFQAAAAAAwDIIKgAAAAAAgGUQVAAAAAAAAMsgqAAAAAAAAJZBUAEAAAAAACyDoAIAAAAAAFgGQQUAAAAAALAMggoAAAAAAGAZBBUAAAAAAMAyCCoAAAAAAIBlEFQAAAAAAADLIKgAAAAAAACWQVABAAAAAAAsg6ACAAAAAABYBkEFAAAAAACwDIIKAAAAAABgGQQVAAAAAADAMggqAAAAAACAZRBUAAAAAAAAyyCoAAAAAAAAlkFQAQAAAAAALIOgAgAAAAAAWAZBBQAAAAAAsAyCCgAAAAAAYBkEFQAAAAAAwDIIKgAAAAAAgGUQVAAAAAAAAMsgqAAAAAAAAJZBUAEAAAAAACyDoAIAAAAAAFgGQQUAAAAAALAMggoAAAAAAGAZBBUAAAAAAMAyCCoAAAAAAIBlEFQAAAAAAADLIKgAAAAAAACWQVABAAAAAAAsg6ACAAAAAABYBkEFAAAAAACwDIIKAAAAAABgGQQVAAAAwP9n786joyjw9f8/nUbZsgpIwCAoVxQRTQYiENe9x/kAACAASURBVCUJCgQVFEUQXIgi8lVhEFkGlLk6NwoG9OayDMtkYGQJjEMULyN6g4IkgMnERkxYRmEy7IqEJSthS7p/f/hLH1sgC+l0Vbrfr3PqHFKpdD/9odLLk+pqAIBpUFQAAAAAAADToKgAAAAAAACmQVEBAAAAAABMg6ICAAAAAACYBkUFAAAAAAAwDYoKAAAAAABgGhQVAAAAAADANCgqAAAAAACAaVBUAAAAAAAA06CoAAAAAAAApkFRAQAAAAAATIOiAgAAAAAAmAZFBQAAAAAAMA2KCgAAAAAAYBoUFQAAAAAAwDQoKgAAAAAAgGk0MjoAgIZjwoQJysnJ8fj1hoeHa86cOVf1s0ZlluqWGwAAAPBVHFEBoMZycnI8/qK/rtdpRGYjrxcAAABo6DiiAkCthIeHKz093WPXFxsbW+fL8HRmyT25AQAAAF/EERUAAAAAAMA0KCoAAAAAAIBpUFQAAAAAAADToKgAAAAAAACmQVEBAAAAAABMg6ICAAAAAACYBkUFAAAAAAAwDYoKSRUVFZoyZYpatWqlgIAADRkyRCdPnjQ6FupZfn6+vvvuO+Xn5xsdBQCczp07p3379ikvL0/l5eVGxwEAAFfh7Nmz2rt3r/Ly8lRRUWF0nAaHokJSYmKi1q1bp+zsbB09elSS9MwzzxicCvXlq6++0oABA9S6dWvdfvvtat26teLi4rRt2zajo3md0tJStWrVSh999JFz3dmzZxUVFaXHH39cdrvdwHRX1rZtWy1dutRlncPhUGBgoD7++GODUsHbFRcXa+rUqWrbtq1uvfVW3XLLLWrfvr3eeecdXbhwweh4AACgBgoKCjRx4kSFhobqtttu0y233KKbbrpJ7733Hn+AqAWfKSrWrFmjrl27yt/fX/3799fEiRM1dOhQSVJycrKmTp2qm2++WUFBQZo9e7bS0tJ08OBBY0PD7datW6eYmBh98cUXLus3btyo2NhYXoS6mb+/vyZPnqyEhAQ5HA5VVFRo2LBhaty4sVatWiU/P/PdBf3www86duyY7rrrLpf1+/fvV0lJibp3725QMnizoqIiRUdHa/bs2SooKHCuP3bsmF5//XU98sgjunjxooEJAQBAdU6fPq2oqCjNmTNHxcXFzvVHjx7VlClTNGzYMI6uqCHzvUqoB8uXL9ekSZO0cOFCFRUVaeDAgZo3b54iIiJUVFSkw4cPq1u3bs7tO3bsqMDAQO3cudPA1HC3oqIiPfnkk7Lb7Zf8Jb9y3VNPPaWioiKDEnqncePG6dixY1q7dq3GjBmjo0ePat26dWrcuLHR0S7LZrPJarWqS5cuLutzc3PVunVrtWvXzqBk8Ga///3vL/uY43A4JElpaWn64x//6OlYAACgFn73u99p7969zsfvSpVff/zxx1qyZIkR0Rocry8qysrKNHHiRCUnJ6t3796yWq0aPXq0KioqFBER4Wy6goKCXH4uODjY+b2UlBT16tVLvXr10qZNmzx+G+AeK1euVFlZ2SV3HJUcDofOnj2r5cuXeziZd2vevLmmTJmi+Ph4paenKy0tTYGBgUbHuiKbzaZOnTqpadOmLutzc3M5mgL1oqSkRO+///4V75skyWKxaP78+aZ9uxQAAL6uoKBAK1eurPLx3M/PT/Pnz69yG/zM64uKjIwM2e12PfDAA851J06ckCRFREQoICBAki75K3phYaECAwNVWFiopKQkpaena/369Xr11Vfr/XCdCRMmaMKECXXeBq4yMzNltVqr3MZqtSorK8tDiXzLmTNnNG3aNLVu3droKFWy2WzKy8tTy5YtXZZZs2YpMjLS6HjwQv/85z915syZKrdxOBw6cOCATp065aFUAACgNnJycqo9p5TdbteePXtUVlbmoVSeU9PXsDXm8HLLli1zdOrUyWXdzJkzHaGhoc6vb7zxRsfSpUudX//73/92SHIcOHDAkZaW5hg/frzze4MGDXLs3bu3XjPHxMQ4JLGwmHKJiYmp1f68cuVKR0hIiGPUqFGOLl26OOx2u8d/H2qTOSQkxDFjxgzHkSNHXJbg4GDH+vXrPZqbhYWFhYWFhYWFxZuWmmokL9elSxfl5eUpIyNDvXr10ocffqjExERFRUU5txkzZoxmzZqlPn36qEWLFpo6dari4uLUoUMHZWZmKiQkxLltSEiIR/6iFRMTo/T09Ct+PzY2VpKq3Aau5s+fr/Hjx1e73Zw5c/TKK694IFHDU7nf1dRnn32ml19+WevXr1e3bt100003KTU1VcOGDavV5VT3+1CV2mTOy8tTQUGB4uLiFBYW5rK+sLCw1m/9qEtu+I6SkhKFhoZW+dcVi8WiDh06KC8vz5QnoQUAwNedPn1abdq0qfKoCj8/P3Xu3Fm7du2SxWLxYLr6V5PXp7V5Xu71z3a6d++u6dOn67HHHlNYWJiys7PVo0cPRUREOLeZNm2aBg0apMjISN1www2qqKhQSkqKJKlFixYuZ2AvKChQixYtPH47UHcjR45U06ZNr3inYLFY1LRpU8XHx3s4mXfKzMzU8OHDtWLFCkVHRzvPVZGQkGDa99nbbDY1a9bskk/8yMzMVLt27Uz/thU0TAEBAXruueeqfMLicDg0btw4SgoAAEzquuuu01NPPVXl47ndbte4ceO8rqSoDz7xjCchIUGnTp1Sfn6+5s6dq3379rkUFVarVe+9955OnjypkpISrV27Vi1btpQk9ejRQ1u3btX58+d1+vRpHThwQB07djTqpqAOgoKCnB+J+esn+35+frJYLFq5cqWCg4MNSug9du/erYEDByopKUmDBw92rh87dqxOnDih1NRUA9Ndmc1mU2RkpBo1cj3YLCsrixNpol7NmDFDXbt2veSJS+XX/fv3129/+1sjogEAgBp69913dcstt1zx8fyRRx7R6NGjjYjW4PhEUfFLxcXFOnTokEtRUZXg4GBNmDBBsbGxeuihh5SUlFTtCRlhXo8++qi+/PJL3X///S7r77//fm3evFlDhgwxKJl3ueOOO3T69OlL7oibNWum48eP64knnjAoWdUqT5z7a4sWLdLatWs9Hwg+IygoSFu2bNGkSZNcytLWrVvrrbfe0ieffKJrrrnGwIQAAKA6LVq0UFZWlsaPH+/80AZJatu2rRITE/Xhhx9e8gcxXJ7PTWn37t0KCAio1VERI0eO1MiRI+sxFTwpOjpan3/+uX766SedPHlSXbt21eeff250LAA+LigoSO+++67eeustHTx4UJ07d9aRI0d4QgMAQANy3XXXac6cOXrnnXd08OBB3X777Tp06BB/7K4ln3v2ExUVpeLiYqNjwARCQ0MVGhpqdAwAcNGkSRPddtttkkRJAQBAA9W0aVN17txZkigproLPvfUDAAAAAACYF0UFAAAAAAAwDYoKAAAAAABgGhQVAAAAAADANCgqAAAAAACAaVBUAAAAAAAA06CoAAAAAAAApsEHtAOolZycHMXGxnr0+sLDw+t8GZ7MXHmddc0NAAAA+CKKCgA1ZsQL7/Dw8Dpdr1FlQV1zAwAAAL6KogJAjc2ZM8foCLXWEDMDAAAAvoxzVAAAAAAAANOgqAAAAAAAAKZBUQEAAAAAAEyDogIAAAAAAJgGRQUAAAAAADANigoAAAAAAGAaFBUAAAAAAMA0KCoAAAAAAIBpUFQAAAAAAADToKgAAAAAAACmQVEBAAAAAABMg6ICAAAAAACYBkUFAAAAAAAwjUZGBwDQcEyYMEE5OTkev97w8HDNmTPnqn7WqMxS3XIDAAAAvoojKgDUWE5Ojsdf9Nf1Oo3IbOT1AgAAAA0dR1QAqJXw8HClp6d77PpiY2PrfBmeziy5JzcAAADgiziiAgAAAAAAmAZFBQAAAAAAMA2KCgAAAAAAYBoUFQAAAAAAwDQoKgAAAAAAgGlQVAAAAAAAANOgqAAAAAAAAKZBUSGpoqJCU6ZMUatWrRQQEKAhQ4bo5MmTRsdCPbHb7dq4caOeffZZPfjgg5KkjRs3ym63G5zM+5SWlqpVq1b66KOPnOvOnj2rqKgoPf7446adedu2bbV06VKXdQ6HQ4GBgfr4448NSgXAnf79739r2rRpGjhwoB599FEtXrxYJSUlRscCgHpz/PhxzZw5Uw8//LAefvhhJSYmKj8/3+hYwGVRVEhKTEzUunXrlJ2draNHj0qSnnnmGYNToT4UFBQoOjpa/fr108qVK5WWliZJ6tevn3r37q2CggKDE3oXf39/TZ48WQkJCXI4HKqoqNCwYcPUuHFjrVq1Sn5+5rsL+uGHH3Ts2DHdddddLuv379+vkpISde/e3aBkANzB4XAoISFBt9xyi2bPnq3/+7//09///ne99NJLuvHGG7V161ajIwKA26WkpKhdu3aaPn26Pv30U3366ad67bXX1K5dO/31r381Oh5wCfO9Sqgna9asUdeuXeXv76/+/ftr4sSJGjp0qCQpOTlZU6dO1c0336ygoCDNnj1baWlpOnjwoLGh4VYOh0OPPvqoMjMzJf18ZIXD4XB+PysrS4MHD3ZZh7obN26cjh07prVr12rMmDE6evSo1q1bp8aNGxsd7bJsNpusVqu6dOnisj43N1etW7dWu3btDEoGwB0WL16sN998Uw6HQw6HQ3a73Xl0V3FxsR544AHl5eUZnBIA3Gfjxo2Kj49XeXm5JLnc7128eFFPP/20Nm/ebGRE4BI+UVQsX75ckyZN0sKFC1VUVKSBAwdq3rx5ioiIUFFRkQ4fPqxu3bo5t+/YsaMCAwO1c+dOA1PD3b766itlZGRcsYhwOBzasmWLtm3b5uFk3q158+aaMmWK4uPjlZ6errS0NAUGBhod64psNps6deqkpk2buqzPzc3laAqggSsvL1dCQsIVv2+321VWVqa5c+d6MBUA1K+3335bki77HLhy3YwZMzyaCaiO1xcVZWVlmjhxopKTk9W7d29ZrVaNHj1aFRUVioiIUHFxsSQpKCjI5eeCg4Od3+vbt69atmzp/CVHw1STtxr4+fkpJSXFQ4l8y5kzZzRt2jS1bt3a6ChVstlsysvLU8uWLV2WWbNmKTIy0uh4AOpgy5Yt+umnn6rcxuFwaOXKlR5KBAD168cff1RGRkaV5wWz2+3atGmTjh8/7sFkQNUaGR2gvlX+Yj7wwAPOdSdOnJAkRUREqEmTJpKkoqIil58rLCx0/tV32bJl2rhxo/P8FZ6QkZEhi8VS7XY12QY1Z7fblZycrOTkZKOjmFZMTEyttk9JSdE777yjUaNGae7cuRo9enSt99ua/j5cSW0yb9++XX/4wx80cuRIl/Vdu3at9REVdc0NsP8Yo6ioiNkD8DmhoaFGR/BavvSY4q7b6vVFRX5+vq6//nqXdatXr1ZoaKjzl/HGG2/Ujh07FB4eLunnk+YVFxfrzjvvlCSFhYV5NrR+fmGVnp5+xe/HxsZKUpXbwNX48eO1YMGCKhtlPz8/vfzyy5o/f74HkzUclftdTX322Wd6+eWXtX79enXr1k033XSTUlNTNWzYsFpdTnW/D1WpTea8vDwVFBQoLi7O5fc+Ly9PhYWFtS4q6pIbsFgsnDPHzbZu3aro6Ohqt2vZsqXzjxoA0JDl5+crNDS02scTi8Wi/Px8tWzZ0kPJfIevPJ7X5PVpbZ6Xe/1bP7p06aK8vDxlZGTowoULWr16tRITE52lhCSNGTNGs2bN0oEDB1RcXKypU6cqLi5OHTp0MC443C4+Pr7aj8O02+2Kj4/3UCLvlpmZqeHDh2vFihWKjo52nqsiISHBtB9LarPZ1KxZs0s+8SMzM1Pt2rUz/dtWAFTtnnvuUfv27av8a4/FYtFzzz3nwVQAUH+uv/56xcXFVfn2Zz8/Pz300EOUFDAVry8qunfvrunTp+uxxx5TWFiYsrOz1aNHD0VERDi3mTZtmgYNGqTIyEjdcMMNqqio4DwFXqhbt2565JFHqtzm4Ycf5oSJbrB7924NHDhQSUlJGjx4sHP92LFjdeLECaWmphqY7spsNpsiIyPVqJHrwWZZWVnsF4AX8PPz08yZM6/4ly0/Pz+FhIRo/PjxHk4GAPXnjTfekNVqvWxZ4efnp0aNGuk///M/DUgGXJnXv/VDkhISElzO8t2hQwe98MILzq+tVqvee+89vffee0bEgwetXr1aI0eO1EcffSSLxSI/Pz9VVFRIkh599FEKKje54447dPr06UvWN2vWzNQnakpKSrrs+kWLFnk4CYD68uSTT6q4uFgTJkzQ+fPnZbVanY8DYWFh+uSTTwx5yycA1JdevXpp3bp1GjFihIqKilzu9wIDA/XBBx/o7rvvNjgl4MoniopfKi4u1qFDh1yOqKjOqFGjlJ2drfPnzys7O1uffPJJPSZEfWrWrJk+/PBD7dq1SytXrlR+fr6WL1+u3Nxc5zlJAADe7cUXX9TQoUO1fPly7d69W++//74+/vhjDRw48JIjqgDAGzzwwAP68ccf9de//lVZWVlaunSpli5dquHDh6tZs2ZGxwMuYXH4wpk9fiEzM1MDBgww9Rm9a3MiEk7UV3e+coIbdzBiv6vrdRr1u8LvKOqK+ybPYdYAfA33e57jK7Ou6WvYmj439rk/G0RFRam4uNjoGAAAAAAA4DK8/mSaAAAAAACg4aCoAAAAAAAApkFRAQAAAAAATIOiAgAAAAAAmAZFBQAAAAAAMA2KCgAAAAAAYBo+9/GkAOomJyfH+TnJnrq+8PDwOl+GJzNXXmddcwMAAAC+iKICQI0Z8cI7PDy8TtdrVFlQ19wAAACAr6KoAFBjc+bMMTpCrTXEzAAAAIAv4xwVAAAAAADANCgqAAAAAACAaVBUAAAAAAAA06CoAAAAAAAApkFRAQAAAAAATIOiAgAAAAAAmAZFBQAAAAAAMA2KCgAAAAAAYBoUFQAAAAAAwDQoKgAAAAAAgGlQVAAAAAAAANOgqAAAAAAAAKZBUQEAAAAAAEyjkdEBADQcEyZMUE5OjsevNzw8XHPmzLmqnzUqs1S33AAAAICv4ogKADWWk5Pj8Rf9db1OIzIbeb0AAABAQ8cRFQBqJTw8XOnp6R67vtjY2DpfhqczS+7JDQAAAPgijqgAAAAAAACmQVEBAAAAAABMg6ICAAAAAACYBkUFAAAAAAAwDYoKAAAAAABgGhQVAAAAAADANCgqAAAAAACAaVBUSKqoqNCUKVPUqlUrBQQEaMiQITp58qTRsRqM4uJibdmyRenp6Tp16pTRcQAAgMkcOnRImzZtUlZWli5evGh0HJhMaWmptmzZos2bN+vEiRNGxwFgAhQVkhITE7Vu3TplZ2fr6NGjkqRnnnnG4FTmV1JSonHjxqlNmzaKiYlRnz591LZtW8XHxys/P9/oeDCB0tJStWrVSh999JFz3dmzZxUVFaXHH39cdrvdwHRX1rZtWy1dutRlncPhUGBgoD7++GODUgFAw7Nz504NGDBAHTp0UN++fRUVFaWwsDDNmjXLtI8B8JyysjK9+uqrzueS9913n9q2baunnnpKP/74o9HxABjIZ4qKNWvWqGvXrvL391f//v01ceJEDR06VJKUnJysqVOn6uabb1ZQUJBmz56ttLQ0HTx40NjQJlZaWqo+ffpo4cKFKisrc66/cOGCUlJS1LNnT8oKyN/fX5MnT1ZCQoIcDocqKio0bNgwNW7cWKtWrZKfn/nugn744QcdO3ZMd911l8v6/fv3q6SkRN27dzcoGQA0LNu3b1evXr30xRdfuKzPz8/XtGnT9Pzzz8vhcBiUDkY7e/as+vXrpzlz5qi0tNS5vry8XB988IF69OhBWQH4MPO9SqgHy5cv16RJk7Rw4UIVFRVp4MCBmjdvniIiIlRUVKTDhw+rW7duzu07duyowMBA7dy508DU5vbee+/pm2++uewTDLvdroMHD2r69OkGJIPZjBs3TseOHdPatWs1ZswYHT16VOvWrVPjxo2NjnZZNptNVqtVXbp0cVmfm5ur1q1bq127dgYlA4CGw+FwaNSoUTp37twVj5xYtmyZPvvsMw8ng1nMnz9fmZmZl/2e3W7Xjz/+qClTpng4FQCz8PqioqysTBMnTlRycrJ69+4tq9Wq0aNHq6KiQhERESouLpYkBQUFufxccHCwiouL9c033+iee+5RdHS07rvvPu3fv9+Im2Eq5eXlWrRoUZXbOBwOpaSkqKioyEOpYFbNmzfXlClTFB8fr/T0dKWlpSkwMNDoWFdks9nUqVMnNW3a1GV9bm4uR1MAQA1lZWVp165dVb69w8/PTwsXLvRgKpiF3W7XggULZLFYqtwmNTWVc1YAPsrri4qMjAzZ7XY98MADznWVd3gREREKCAiQpEteUBcWFiowMFBt27ZVWlqatmzZosmTJ+vNN9/0XHiTOn78eI3e1nHu3Dnt3bvXA4nQEJw5c0bTpk1T69atjY5SJZvNpry8PLVs2dJlmTVrliIjI42OBwANwo4dO6rdxm6365tvvvFAGphN5RHN1b315+LFi9qzZ4+HUgEwk0ZGB6hv+fn5uv76613WrV69WqGhoQoNDZUk3XjjjdqxY4fCw8Ml/fxe9OLiYt15551q06aN8+euvfZaNWrkmZFlZGRU2TJXqsk2RurRo4fREWrE7HM0k5iYmFptn5KSonfeeUejRo3S3LlzNXr06FrPu6a/D1dSm8zbt2/XH/7wB40cOdJlfdeuXWt9REVdcwPsP57DrI1x/PhxZo8q9enTx+gIXovfPc/xpVm767Z6fVHRpUsX5eXlKSMjQ7169dKHH36oxMRERUVFObcZM2aMZs2apT59+qhFixaaOnWq4uLi1KFDB+c2lX8NXr58uUdyx8TEKD09/Yrfj42NlaQqt6kvDodDnTt31r/+9a8qD+m87rrr9OOPP5r2XASVLBYLJ/Oqocr9rqY+++wzvfzyy1q/fr26deumm266SampqRo2bFitLqe634eq1CZzXl6eCgoKFBcXp7CwMJf1hYWFtS4q6pIb4L7Jc5i1+33//ffq3Llzldv4+fnpmWee0bJlyzwTCqbhcDjUrVs35ebmVvlc0t/fXz/99JOaN2/uwXS+gfs9z/GVWdfk9Wltnpd7/Vs/unfvrunTp+uxxx5TWFiYsrOz1aNHD0VERDi3mTZtmgYNGqTIyEjdcMMNqqioUEpKivP7Fy5c0NChQ/X73//+khPs+SKLxaLx48dX+7FiL774oulLCtSfzMxMDR8+XCtWrFB0dLTzXBUJCQmm/Ug6m82mZs2aXfKJH5mZmWrXrp3p37YCAGZx2223qW/fvlV+upPdbtfYsWM9mApmUdPnkqNHj6akAHyU1xcVkpSQkKBTp04pPz9fc+fO1b59+1yKCqvVqvfee08nT55USUmJ1q5dq5YtW0qSKioq9OSTT+qxxx7T4MGDjboJpvPiiy9qxIgRkuTyJKTyUJ/77rtPb7zxhiHZYLzdu3dr4MCBSkpKcvm9GTt2rE6cOKHU1FQD012ZzWZTZGTkJW/xysrK4kSaAFBLy5Ytu+wnJVmtVkk/f4IY5/7xXfHx8Ro1apSkyz+XjIqK0owZMwzJBsB4Xv/Wj18rLi7WoUOHXIqKqqSmpiotLU0nT55USkqKunbtqvnz59dzSvPz8/NTSkqK7rvvPs2bN0+7du2SJN10000aN26cxo4dq2uvvdbglDDKHXfcodOnT1+yvlmzZjp+/LgBiWomKSnpsuur+5QbAMClbrjhBtlsNiUlJSk5Odn5uHDfffdp4sSJGjBggMEJYSSLxaIlS5YoOjpac+fO1bfffitJateuncaOHavx48erSZMmBqcEYBSfKyp2796tgIAAdezYsUbbDx8+XMOHD6/nVA2Tn5+fRo8ereeff14lJSUKCgpSXl6eT50sBgAAXFmrVq30zjvv6O2331ZRUZFatGihzz//3OhYMAmLxaL4+HjFx8erpKREgYGBOnjwIM8lAfheUREVFaXi4mKjY3gVi8WiwMBA578BAAB+yWq16rrrrjM6BkwsICBAEs8lAfzMJ85RAQAAAAAAGgaKCgAAAAAAYBoUFQAAAAAAwDQoKgAAAAAAgGlQVAAAAAAAANOgqAAAAAAAAKZBUQEAAAAAAEyjkdEBADQsOTk5io2N9ej1hYeH1/kyPJm58jrrmhsAAADwRRQVAGrMiBfe4eHhdbpeo8qCuuYGAAAAfBVFBYAamzNnjtERaq0hZgYAAAB8GeeoAAAAAAAApkFRAQAAAAAATIOiAgAAAAAAmAZFBQAAAAAAMA2KCgAAAAAAYBoUFQAAAAAAwDQoKgAAAAAAgGlQVAAAAAAAANOgqAAAAAAAAKZBUQEAAAAAAEyDogIAAAAAAJgGRQUAAAAAADANigoAAAAAAGAaFBUAAAAAAMA0KCoAAAAAAIBpUFQAAAAAAADToKgAAAAAAACm0cjoAIAnnTt3Ths2bNDXX3+tPXv26OzZs5Kk6dOnKzIyUgMGDFCTJk0MTgkAAAAAvouiAj6huLhYM2fO1JIlS3Tq1ClZrVbdeuutCgwMlCTNnj1b5eXlatGihUaPHq3XX3/d+T0AAAAAgOfw1g94vc2bN6tr166aPXu2YmNj9fnnn6ukpER79uxRVlaWJKmkpERffPGF+vTpo3fffVd33HGHvvzyS4OTAwAAAIDvoaiAV0tNTVX//v3VpEkTffXVV/rwww/Vr18/NW3a1GW7Jk2aqG/fvkpNTdVXX32lZs2aKS4uTmvWrDEoOQAAAAD4JooKeK2srCw9+eST6tGjh2w2m3r16lWjn+vZs6e+/vpr9ezZU0899ZQyMzPrOSkAAAAAoBJFBbzS2bNn9eyzz+qGG27Qp59+WuvzTQQGBmr9+vUKCwvTs88+q7KysnpKCgAAAAD4JYoKSVOnTlWXLl0UGBiotm3b6oUXXtDp06eNjtUg5OXlafLkyerevbsk6aWXXtLOnTsNyEIw5wAAIABJREFUTiUtWLBA+/bt09KlSxUUFHRVlxEUFKS//OUv+te//qUFCxa4OSEAAAAA4HIoKiRZrValpKTo1KlTys3N1dGjR/Xcc88ZHcv0/vznP+vWW29VUlKSvvnmG0nSn/70J91111166623DMtlt9u1aNEiRUdH6/7776/TZfXp00cxMTFatGiR7Ha7mxICAAAAAK7EZ4qKNWvWqGvXrvL391f//v01ceJEDR06VJI0c+ZMRURE6JprrlGrVq00btw4paenGxvY5L744guNGTNGdrtdDofDub7y32+88YZWrlxpSLZvv/1W+/fv1+jRo91yeaNHj9aBAwecZQwAAAAAoP74RFGxfPlyTZo0SQsXLlRRUZEGDhyoefPmKSIi4rLbb9q0SXfeeaeHUzYss2fPlp/flXcfPz8/zZw506XE8JTt27dLku699163XF7l5VBUAAAAAED98/qioqysTBMnTlRycrJ69+4tq9Wq0aNHq6Ki4rJFxUcffaQ///nPmjt3rnNdSkqKevXqpV69emnTpk2ejG9KhYWF2rhxY5VvhbDb7fr+++/13XffeTDZz77//ns1a9ZMHTp0cMvltW/fXs2bN9f333/vlssDAAAAAFTB4eU+++wzR3BwsMu6gwcPOiQ5jh075rJ+zZo1jpCQEMeXX37pXFdQUOCIiIhwnDt3znHy5ElH165dHeXl5fWaOSYmxiGJhYWFhYWFhYWFhYWFhcVrlppqJC+Xn5+v66+/3mXd6tWrFRoaqtDQUOe6999/X5MmTdInn3yie+65x7k+OztbvXv3VuPGjdW4cWN16NBB//73v9WpU6d6zR0TE1PleTJiY2MlyZBzaZw9e1YhISE6f/58ldtZLBYdPnxYYWFhHkr2s9dee03//d//rTNnzuiaa66pdnuLxVLlW1TKy8vVvHlzTZgwQbNmzXJnVAC4ourum+A+zNpzmDWqwv7hOczac3xl1jV5fVq5TU14/Vs/unTpory8PGVkZOjChQtavXq1EhMTFR4e7txm3rx5mjx5sjZs2OBSUkjSqVOnFBIS4vw6JCREp06d8lh+M2ratKmefvrpas9RERcX5/GSQpLuvPNOXbx4UXv27HHL5f3zn//UhQsXdNddd7nl8gAAAAAAV+b1RUX37t01ffp0PfbYYwoLC1N2drZ69Ojhcn6KV155RcXFxerTp4/8/f2diyS1aNFCBQUFzm0LCgrUokULj98Os3nttdcUGBh42bLCz89P11xzjWEfUdqzZ09J0oYNG9xyeZWX06NHD7dcHgAAAADgyry+qJCkhIQEnTp1Svn5+Zo7d6727dvnUlQ4HA5dvHhRpaWlLov084vTrVu36vz58zp9+rQOHDigjh07GnVTTKNjx47KyMi47CzatGmjzz//XN27dzcgmXTTTTcpJiZGf/rTn1RRUVGny6qoqNDixYsVHR3N/zsAAAAAeIBPFBW/VFxcrEOHDl3xo0l/LTg4WBMmTFBsbKweeughJSUlyWq11nPKhuHOO+/U3r17tXHjRv3nf/6nJGndunU6dOiQoqOjDc32yiuv6MCBAy6f3nI15s2bp/379+uVV15xUzIAAAAAQFUsDl84s8cvZGZmasCAASoqKpLFYjE6zmXV5kQkRpxM80rMdKIYh8OhRx55RF988YUyMzOrLKaulDsnJ0e9evVS37599fe//920+wsA72Sm+1Rvx6w9h1mjKuwfnsOsPcdXZl3T17A1ff3qc0dUREVFqbi4mBedXs5isehPf/qTWrVqpf79+8tms9Xq57dv367+/furVatWSk5OZn8BAAAAAA/xuaICvqNNmzb68ssv1axZM0VFRSkhIUFnz56t8mfOnTunt956S1FRUWrSpIk2bdqkNm3aeCgxAAAAAICiAl7tP/7jP7Rjxw4NGzZMb775psLCwjRp0iStX79eR44cUWFhoSRp/fr1mjRpksLCwvTGG2/o8ccf17fffqtbbrnF4FsAAAAAAL6lkdEBgPrWokULrVq1SmPGjNEf//hHzZ07V0lJSS7bDBo0SFarVY8++qjGjh3rfI8VAAAAAMCzKCrgM2JiYhQTE6PS0lLl5uZq9+7dKisr08SJE7V161aFh4fL39/f6JgAAAAA4NMoKuBz/P39dc899+iee+6RJL366qsGJwIAAAAAVOIcFQAAAAAAwDQoKgAAAAAAgGlQVAAAAAAAANOgqAAAAAAAAKZBUQEAAAAAAEyDogIAAAAAAJgGRQUAAAAAADANigoAAAAAAGAaFBUAAAAAAMA0KCoAAAAAAIBpUFQAAAAAAADToKgAAAAAAACmQVEBAAAAAABMg6ICAAAAAACYBkUFAAAAAAAwDYoKAAAAAABgGhQVAAAAAADANBoZHQCoqwkTJignJ8fj1xseHq45c+Z4/HqNxKxRFaP2D6l2+4iROWsrNjbW6AhVqmruDWnOErP2pIY861/jfs/9Gvr+wazdh1l7jhmfa3NEBRq8nJwcj99JGXGdZsCsURWj/q9qe70NZZ+KiYkxOkKVqptjQ5mzxKw9qaHPuq7bu0tDyVlb3rB/MGv3YNaeY9Y5ckQFvEJ4eLjS09M9dn1mb0XrE7NGVTy9f0hXt48YkdPb1GTuzNk9mLXnNJT7k4aS09vUdO7Muu6YteeY9bk2R1QAAAAAAADT4IgK1ElFRYX+9a9/6ejRo5KkXbt2qXPnzmrUiF0LAAAAAFB7HFGBWrPb7dqwYYMGDx6s4OBgde7cWf369ZMk3XnnnQoICFD//v21du1alZeXG5wWgBm1bdtWTZs2lb+/v4KCgjRgwAAdOXLE6FiGyM/Pl8ViueT9oYcOHZLFYtF3331nUDLvw6w9gzmjOuwjnsOsPYdZuxdFBWpl79696t27twYMGKCsrCyNHDlSy5Yt05YtWyRJq1at0ksvvaTvv/9eQ4YMUUREhL755huDUwMwkx9++EHHjh3Tjh07VFpaqv379ys/P1/Tpk0zOpohbDabmjRpojvuuMNl/ddff62AgADdeuutBiXzPszaM5gzqsM+4jnM2nOYtXtRVKDG1q5dq/DwcH333XdasmSJDh8+rAULFig+Pl69e/eWJD355JNKSkrSgQMHlJqaqtOnT6tHjx5avHixwekBmIXNZlNgYKBuu+02SVKLFi30m9/8RsePHzc4mTG2b9+uiIiIS94y9/XXX6tbt27y8+Oh2l2YtWcwZ1SHfcRzmLXnMGv3Ylqokb///e8aNmyYIiIitGfPHj3//PNq3LjxFbe3Wq16/PHHtWfPHg0YMEAvvfSSlixZ4sHEAMzKZrMpMjJSFotF5eXlSktL09/+9jc9+eSTRkczxPbt2xUZGXnJ+q+//vqy63H1mLVnMGdUh33Ec5i15zBr96KoQLV+/PFHxcfHKyIiQhs2bFCbNm1q/LPBwcFau3at4uLiNHbsWO3Zs6cekwJoCGw2m7Zt26bg4GA1adJEw4YN09KlSzVq1Cijoxnim2++ueQJjN1u144dOxQZGamTJ0+qV69eiomJUWRkpL744guDkjZ8zNozmDOqwz7iOczac5i1e/HRDJI++OADLViwQLm5uSorK+MEkL8ybtw4nTt3TqtXr1ZAQECtf/7aa6/VihUrdPvtt+v5559XVlaWLBZLPSQF0BBs375df/3rX/Xoo4/q2LFjuv/++/X9998bHcsQlefr6Natm8v6nJwclZaWqmfPngoJCdG2bdtktVqVl5enESNGOE9gjJpj1p7BnFEd9hHPYdaew6zdjyMqJIWEhOjll1/WnDlzjI5iOnl5efr44481ZcoU3XLLLVd9Oddff71mzJih7OxsffXVV25MeHXatm2rpUuXuqxzOBwKDAzUxx9/bFAq71NaWqpWrVrpo48+cq47e/asoqKi9Pjjj8tutxuYDkbIy8tTQUGBfvOb30iS2rRpo0mTJmnx4sXO/WHbtm0uR1c88cQTXntS3sqPdg4ODnZZv3r1avXs2VPt2rWT1WqV1WqVJJWUlOiuu+7yeE5vwKw9gzlX7f3335e/v/8lS+VMSktLjY5Y79hHPIdZew6zdj+fKSrWrFmjrl27yt/fX/3799fEiRM1dOhQSVJcXJxGjBihm2++2eCU5rNkyRI1atRIL774Yp0v6+mnn1ZQUJCSk5PdkOzqVTaev75z2L9/v0pKStS9e3eDknkff39/TZ48WQkJCXI4HKqoqNCwYcPUuHFjrVq1ipMK+SCbzabrrrtO7du3d6575JFHdPz4cW3btk2S1L17d3377beSpM2bNysoKOiSv1B4i86dOysoKEiJiYkqLCzU6dOntXjxYi1cuFCJiYnO7Q4cOKB7771X/fv31+DBgw1M3HAxa89gzlV77rnnVFpa6rL85S9/0TXXXKMlS5bI39/f6Ij1jn3Ec5i15zBr9/OJVwnLly/XpEmTtHDhQhUVFWngwIGaN2+eIiIijI5metu2bdPdd9+ttm3b1vmymjdvrv79+ztfjBjFZrPJarWqS5cuLutzc3PVunVrtWvXzqBk3mncuHE6duyY1q5dqzFjxujo0aNat25dlSdjhfey2WyX3Pe2bNlSUVFR+vDDDyVJTZo0UZMmTVRQUKA333xTM2bMMCKqRwQGBmr9+vXavn27wsLCdNttt2nt2rVKS0tTTEyMc7ubbrpJ27Ztk81m07hx4wxM3HAxa89gzrWzcuVKjRw5UkuXLtVzzz1ndByPYB/xHGbtOcza/bz+HBVlZWWaOHGiUlJSnB+hOXr0aL3yyis1LipSUlK0YMECSdLbb7+t+++/v97ymonD4VBOTo5bHzi7deum1NRUFRYWXnJolKfYbDZ16tRJTZs2dVmfm5vL0RT1oHnz5poyZYri4+PVunVrZWZmKjAw0OhYMEhSUtJl12/dutXl6x49euiFF17QkCFD1KpVK09EM8y9995b5Vvizp8/7yz2AgMDr+pcQfgZs/YM5lwzf/7zn/Xb3/5Wq1at0pAhQ4yO41HsI57DrD2HWbuX1xcVGRkZstvteuCBB5zrTpw4IUk1KioKCwuVlJSkrKwslZaWqk+fPvr222+d7y/yZufPn9eZM2dq9Skf1QkNDZUknT592tCiIi8vTy1btnRZX1paqtdee82QTL7gzJkzmjZtmlq3bm10FDQAPXv21FtvvaUPPvjA6CiG27Fjh6ZOnSqr1ary8nLOp1SPmLVnMGdp/vz5+t3vfqfU1FQNGjTI6Dimwz7iOczac5h1LTm83LJlyxydOnVyWTdz5kxHaGjoJdtu3rzZYbVaXdalpaU5xo8f7/x60KBBjr1799ZP2P9fTEyMQxJLLZaYmJgazzckJMQxY8YMx5EjR1yW4OBgx/r16/k/cuOsHQ6HY+XKlY6QkBDHqFGjHF26dHHY7fZa/bwvz7ohLrXdP65k7Nixjo0bN9bbPuKunL6sJnNnzu7BrD3HE/cns2fPdjRt2tSxYcMGU+fEpWo6d2Zdd8zaczz9XLumvP4cFV26dFFeXp4yMjJ04cIFrV69WomJiQoPD3duU1FRoXPnzunChQuSpHPnzuncuXNyOBw6deqUQkJCnNuGhITo1KlT9Z47JiZGDofjiktMTEy127hjueGGGzRixIgabSup2m2mTJmia6+9VufPn3dbxl++76s6lZ84EBcXp7CwMOdy7tw5FRYW1uqtH56Yv9mW2sxakj777DO9/PLL+t///V/NmzdP+fn5Sk1NrdVl+OqsG+JS2/3jco4ePapHHnlEQUFBtXqbXW32EXfkxM+qmjtzdi9m7Tn1eX/y1ltv6b/+67/06aefqn///qbNiSuryXN0uAez9hx3PNeuyevT2vyfef1bP7p3767p06frsccek9Vq1YgRI9SjRw+Xt32sXLnS5TwMlecuOHDggFq0aKGCggLn9woKCtSiRQvP3QCDde/eXdnZ2XI4HLJYLHW+vH/84x+66667dO2117ohXe3ZbDY1a9bskk/8yMzMVLt27XhbghtlZmZq+PDhWrFihaKjoyVJU6ZMUUJCgh5//HE+8QOXFRYWpnXr1hkdAwDc7vXXX9eCBQu0YcMG3XPPPUbHAQBT84lXCgkJCTp16pTy8/M1d+5c7du3z6WoePbZZy/b+HTo0EE9evTQ1q1bdf78eZ0+fVoHDhxQx44dDbw1njVw4EDt37/fLZ/UkZeXp61bt+qhhx5yQ7KrY7PZFBkZqUaNXDu6rKwsTqTpRrt379bAgQOVlJTk8tFLY8eO1YkTJ67qqAoAABqqnJwcvfPOOyorK1NcXJz8/f1dFs6RBQCuvP6Iil8rLi7WoUOHavyJH8HBwZowYYJiY2Ml/XzGel84kWalESNGaPLkyUpMTNS9995bp6MqZs2apUaNGumFF15wY8LaudInDixatMjDSbzbHXfcodOnT1+yvlmzZjp+/LgBiQAAME54eLgcDofRMQCgwfCJIyp+affu3QoICKjVUREjR45UVlaWsrKy1K9fv3pMZz7NmzfXG2+8oc8++0yrVq266svZtGmTlixZovHjx6tt27ZuTAigofrhhx80YcIE59dJSUm69957nV+/+uqr6t27t1555RUj4rlN5e3Mzs5WVFSUevfurVdffdX5/ZreTndv540qZ/3jjz/qN7/5jZo0aaLy8nLn95l1/aic+8GDB9W6dWvFxsZWe/4FZuy72F/qF/eDnsPje/3yuaIiKipKxcXFbjnfgq945ZVXdM8992jMmDHasmVLrX9+165deuKJJ3Trrbfq7bffroeEABqiL774wln+nj9/Xrm5uc7v7dixQ2fOnNHWrVt14cIF2Ww2o2LWWeXtbN++vb788ktt3bpV+fn52rVrV41vp7u381aVs77uuuu0adMm9ezZ0/k9Zl1/fvm73K9fP6Wnp+vzzz+/4vbM2Lexv9Qv7gc9h8f3+uVzRQVqz2q1au3atWrfvr3i4uK0aNEi2e32an/O4XDob3/7m6Kjo9W4cWN9+umnzhOVAvAt6enpCgkJUWxsrNq3b6/BgwcrPT3defbnJUuWKD4+3rl9VlaW+vbtK0nq27ev/vGPfxiSu7aqup2hoaFq0qSJJKlRo0ayWq01vp3u3s4bVDXrJk2auHxil+T+GfrSrH+put/lzZs3q3fv3vqf//mfK14GM/YNl9tXKtezv9RddfPlftB9qps1j+/1g6ICNXL99ddry5Yt6t27t15++WVFR0dr7dq1LoeSVbLb7dqwYYMefPBBDR8+XJ06ddK2bdt86iSkAFxFR0fr7rvvdj6oL1iwQGVlZfL399fFixeVkZGh++67z7l9YWGhAgMDJUlBQUEun75kZlXdzko7d+7UyZMndfvtt9f4drp7O29Qk1n/ErN2j6rm3qZNG+3bt0+bN2/Wxo0btXPnzsteBjP2DZfbVxwOB/uLm1Q338vhfvDq1HTWPL67l8+dTBNXr1WrVtqwYYOWLFmit956S0OGDJG/v78iIiJ08803S5Luv/9+7dixQ4WFhbr++us1e/Zsvfrqq5d8ygYA37J//37n/cSRI0d04sQJ58cEr1y5Uk8++aTL9sHBwSouLpb080mQg4ODPRv4KlV1OyXp9OnTGjdunNasWSOp5rfT3dt5g+pm/WvM2j2qmnvjxo3VuHFjST9/atju3bt15513XnIZzNi7/PTTTxo+fLjLutDQUL399tsu+8oNN9ygnJwc9pdautr5Xg73g1Wry6x5fHc/jqhArVgsFr3wwgs6cOCA1q1bp2effVbl5eXavHmzJKmoqEhPPPGEPvjgAx0+fFhTpkyhpACgPXv2qEuXLqqoqJCfn58+//xz53uU9+7dq0WLFmnAgAHas2eP5s+fr169emnTpk2SpI0bN7q8x9bMqrqd5eXlevrpp/Xuu+8qNDRUki57O8vLyy/5dJy6bOetqpr15TBr96hq7iUlJc7tvvrqK3Xs2JEZ+4DQ0FClp6e7LB988MEl+4ok9percLXzvRzuB6t2tbPm8b1+UFTgqlitVj388MOaP3++MjMzdejQITkcDm3fvl2LFy/WE0884WzJAaDyQf78+fPKz8/Xpk2b1L17d0k/f3Txhg0blJaWpi5duui3v/2t80zlvXv3lp+fn+6++26Db0HNVHU7U1NTZbPZNHXqVMXGxiorK+uyt/PgwYP6/e9/73K5ddnOW1U164sXL6pv377Kzc1VXFycsrOzmbWbVDX3rVu3qlu3boqKilLbtm3Vo0cPZuzDfr2vHDt2TN988w37i5tUN1/uB92nulnz+F4/+FM3AKDevf76685/79q1S2vWrHH+VeKXtm3b5vz33LlzPZLNnaq6nSNGjNCIESMu+Zlf387c3Fy3buetqpr1Nddco40bN17yM8y67qqa+4MPPqgHH3zQZXtm7Lt+va9I0pAhQ9hf3KS6+XI/6D7VzZrH9/pBUQEA8Lhhw4YZHcEjruZ2DhkyxK3b+QpmbYzq5s6M8UvsL/WL+0HPYdb1j6ICXiEnJ0exsbEevb7w8HCPXZ+ZMGtUxdP7R+V11nYfMSKnt6nJ3JmzezBrz2ko9ycNJae3qencmXXdMWvPMetzbYoKNHhG/GKFh4eb8he6vjFrVMWo/6fa7iPsT+5R3dyZs/swa89pKPcnDSWnt6nJ3Jm1ezBrzzHrc22Lw+FwGB0CripbwfT09DptAwAAAABAfavpa9iavn7lUz8AAAAAAIBpUFQAAAAAAADToKgAAAAAAACmQVEBAAAAAABMg6ICAAAAAACYBkUFAAAAAAAwDYoKAAAAAABgGhQVAAAAAADANCgqAAAAAACAaVBUAAAAAAAA06CoAAAAAAAApkFRAQAAAAAATIOiAgAAAAAAmAZFBQAAAAAAMA2KCgAAAAAAYBoUFQAAAAAAwDQoKgAAAAAAgGlQVAAAAAAAANOgqAAAAAAAAKZBUQEAAAAAAEyDogIAAAAAAJgGRQUAAAAAADANigoAAAAAAGAaFBVVqKio0JQpU9SqVSsFBARoyJAhOnnypNGxAAAAAADwWhQVVUhMTNS6deuUnZ2to0ePSpKeeeYZg1MBAAAAAOC9KCokffXVV4qLi1Pr1q0VHBysoUOHSpKSk5M1depU3XzzzQoKCtLs2bOVlpamgwcPGhsYAAAAAAAv5fNFxUcffaSHH35YY8aM0eHDh3XkyBGNHj1aRUVFOnz4sLp16+bctmPHjgoMDNTOnTsNTAwAAAAAgPdqZHQAI505c0b/7//9P82dO1dDhgyRJDVu3FhxcXE6cuSIJCkoKMjlZ4KDg1VcXFzv2fYfPqZps5Kr/L6kKrcBAAAAAKC+1eT1aeU2NeHTRUVGRoYsFoueeuqpS74XEBAgSSoqKnJZX1hYqMDAwHrNFR4ervDwcCVOHXPFbc4d+6ckVbkNAAAAAAD1rSavTyu3qQmLw+Fw1DlVA7VixQq9/fbb2rdv32W/3759e7355psaNWqUJGn//v3q2LGjDhw4oA4dOngwKQAAAAAAvsGni4o9e/YoPDxca9eu1UMPPaTi4mJlZ2crLi5OkjRjxgytWLFCaWlpatGihZ5//nmVlJQoLS2t3rPxlg4AAAAAgDep6TsCfLqokKTly5dr5syZ+uGHHxQQEKBRo0ZpxowZkqSKigpNnTpVy5Yt0/nz59WvXz8lJyerZcuWBqcGAAAAAMA7+XxRAQAAAAAAzMPnP54UAAAAAACYB0UFAAAAAAAwDYoKAAAAAABgGhQVAAAAAADANCgqAAAAAACAaVBUAAAAAAAA06CoAAAAAAAApkFRAQAAAAAATIOiAgAAAAAAmAZFBQAAAAAAMA2KCgAAAAAAYBoUFQAAAAAAwDQoKgAAAAAAgGlQVAAAAAAAANOgqAAAAAAAAKZBUQEAAAAAAEyDogIAAAAAAJgGRQUAAAAAADANigoAAAAAAGAaFBUAAAAAAMA0KCoAAAAAAIBpUFQAAAAAAADToKgAAAAAAACmQVEBAAAAAABMg6ICAAAAAACYBkUFAAAAAAAwDYoKAAAAAABgGhQVAAAAAADANCgqAAAAAACAaVBUAAAAAAAA06CoAAAAAAAApkFRAQAAAAAATIOiAgAAAAAAmAZFBQAAAAAAMA2KCgAAAAAAYBoUFQAAAAAAwDQoKgAAAAAAgGlQVAAAAAAAANOgqAAAAAAAAKZBUQEAAAAAAEyDogIAAAAAAJgGRQUAAAAAADANigoAAAAAAGAaFBUAAAAAAMA0KCoAAAAAAIBpUFQAAAAAAADToKgAAAAAAACmQVEBAAAAAABMg6ICAAAAAACYBkUFAAAAAAAwDYoKAAAAAABgGhQVAAAAAADANCgqAAAAAACAaVBUAAAAAAAA06CoAAAAAAAApkFRAQD4/9i7+7io6rz/4+8BC0HuTFnNME2vtd3QAhUVUsE2xUrNxTSzslKzLa011MVuNhWztG0JrKwLszRvarU0u3HJboQ0FVFDs36b4T1G4h133gvn90eXs00qNzLOOTPzej4e30dx5syZN1+Hz5z5zDlnAAAAAMugUQEAAAAAACyDRgUAAAAAALAMGhUAAAAAAMAyaFQAAAAAAADLoFEBAAAAAAAsg0YFAAAAAACwDBoVAAAAAADAMmhUAAAAAAAAy6BRAQAAAAAALINGBQAAAAAAsAwaFQAAAAAAwDJoVAAAAAAAAMugUQEAAAAAACyDRgUAAAAAALCMemYHALzRmDFjlJeXZ8pjR0ZGKi0t7aLua1buumQGYA3Uvdqh7gEAvBlHVAAmyMvLM2XHt66Pa0Zus+YKgHNR96z9mAAAWAlHVAAmiYyMVFZWlksfMz4+vs7bcHVuZ2QGYA3UvZqh7gEAvB1HVAAAAAAAAMugUQEAAAAAACyDRgUAAAAAALAMGhUAAAAAAMAyaFQAAAAAAADLoFEBAAAAAAAsg0YFAAAAAACwDBoVkioqKjR+/HiFhYUpKChIAwYM0MHGml7CAAAgAElEQVSDB82OBQAXpbKy0uwIXsEwDOYagCVRmwC4OxoVkqZNm6Zly5YpJydHBQUFkqR7773X5FSAo2bNmmn27NkOywzDUHBwsJYuXWpSqqqVl5crLCxM77//vn3Z8ePHFRsbqzvuuIMdKSfauHGj7r33Xvn7+8vX11dXX321pk6dqiNHjpgdzeNkZ2crMTFR9evXV7169dSmTRu99NJLOnr0qNnRPIo71w93rNdwfwcOHNCkSZPUrFkz+fr6qkGDBho2bJi2bNlidjQAqDWvaVQsWrRI7dq1U2BgoHr16qWkpCQNHDhQkpSRkaHk5GS1atVKISEheuGFF5SZmaldu3aZGxr4P/v27VNhYaFuuOEGh+U7duxQWVmZOnbsaFKyqgUGBmrcuHFKSUmRYRiqqKjQoEGD5OfnpwULFsjHx2tK0CX1zjvvqFOnTlq4cKFOnDghSSooKNDTTz+t6OhoFRYWmpzQc6Snpys+Pl7Lli3TqVOnZBiG8vPzlZSUpLi4OJWUlJgd0WO4a/1w13oN97Zr1y61b99ekydPttf8Y8eOae7cuerYsaOWLVtmckIAqB1rvso72dy5czV27FjNnDlTJSUl6tOnj2bMmKGoqCiVlJRoz5496tChg3391q1bKzg4mA40LCM3N1e+vr6KiIhwWL5582Y1adJEzZs3NylZ9UaPHq3CwkItWbJEI0eOVEFBgZYtWyY/Pz+zo3mEH3/8Uffee+85pyEYhiFJ2rlzp+6++26z4nmUNWvWaMyYMZJ03rnetGmTRo8ebUo2T+WO9cOd6zXck2EYGjhwoH766adzbqusrNSZM2d05513at++fSakA4CL4/GNimPHjikpKUkZGRnq1q2bfH19NWLECFVUVCgqKkqlpaWSpJCQEIf7hYaG2m+bP3++YmJiFBMToy+++MLlvwOQm5urNm3ayN/f32H55s2bLf/pXIMGDTR+/Hjdd999ysrKUmZmpoKDg82O5TFee+01VVZW2t8s/1ZlZaVWrlyp7777zsXJPM/LL79c5af4hmHo3Xff1c8//+zCVJ7NHeuHO9druKecnBxt2LDhgqdDGYahkydPatasWS5OBgAXz+MbFdnZ2aqsrNQtt9xiX3bgwAFJUlRUlIKCgiTpnMN1i4uLFRwcrOLiYqWmpiorK0sff/yxHn/8cVVUVFzSzGPGjLF/aleXdeA5cnNzlZ+fr8aNGzuM6dOnKzo62ux4NXL06FFNmDBBTZo0MTuKR1m+fPkFmxS/9umnn7ogjWdbvnx5tddFOHPmjFauXOmiRN7DneqHJ9RruJfMzEynrgcAF6Om72FrzPBwc+bMMdq0aeOw7LnnnjOaNm1q//nqq682Zs+ebf95+/bthiRj586dRmZmpvHYY4/Zb+vbt6/xww8/XNLMcXFxhiSGh4+4uLgaPycaNmxoTJ061di7d6/DCA0NNT7++GOXPrdqk9swDGPevHlGw4YNjWHDhhkRERFGZWVlre7P3wOD4TnD1fXDWTXE1fWausdgMBgMTx015fFHVERERCg/P1/Z2dk6deqUFi5cqGnTpikyMtK+zsiRIzV9+nTt3LlTpaWlSk5OVkJCglq2bKlDhw6pYcOG9nUbNmyoQ4cOXfLccXFxMgzjgiMuLq7adRjWHXFxcTV+LuTn5+vIkSNKSEhQeHi4fZw4cULFxcW1PpS4Ls+b2uSWfvkE+pFHHtEHH3ygGTNmqKioSIsXL67VNuqa2dNH//79a3RRwY8++sj0rO4+OnXqVKO53rBhg+lZrTjMqh+S6+qeM+s1dY9R07Fw4cJqn08+Pj4aOnSo6VkZDIbnjpq8P63Na6rHNyo6duyop556SomJiQoPD1dOTo46d+6sqKgo+zoTJkxQ3759FR0drauuukoVFRWaP3++JKlRo0YOX+935MgRNWrUyOW/B7xXbm6uAgICzrmC/Jo1a9S8eXPLHgq9Zs0aDR48WG+//ba6d+9uP9c8JSXF0l8r6G4efvjhKufTx8dH4eHhDqe/4eI88sgj1c51hw4dHC7OjIvjrvXDXes13FtiYqIaNWokm812wXUqKyv18MMPuzAVANSNxzcqJCklJUWHDh1SUVGR0tPTtW3bNodGha+vr1588UUdPHhQZWVlWrJkiRo3bixJ6ty5s1atWqWTJ0/q8OHD2rlzp1q3bm3WrwIvlJubq+joaNWrV89h+dq1ay17YbatW7eqT58+Sk1NVf/+/e3LR40apQMHDlz0p6I4V8+ePXXPPfec9zYfHx/ZbDa98cYb8vX1dXEyzzNkyBD16tXrvLf5+PjIz89Pr732motTeR53rh/uWK/h/vz8/JSRkSGbzXbBo77+8pe/qHPnzi5OBgAXr171q3iW0tJS7d6926FRUZXQ0FCNGTNG8fHxkqTU1FR2+OFSqamp511u5TdEbdu21eHDh89ZHhAQoP3795uQyHPZbDbNmTNHrVq1Unp6usOFgdu1a6fU1FTddNNNJib0HJdddpmWLVumCRMmaNasWTp27Jj9ti5duig9PZ03o07gzvXDHes1PENiYqI++ugjjR8/Xt9//719+RVXXKFx48YpOTm5yiMuAMBqvOKIil/bunWrgoKCanVUxNChQ7V27VqtXbtWPXv2vITpAKD2fH19NXnyZBUWFurf//63JGnjxo365ptvaFI4Wf369ZWWlqbCwkJ99NFHkn55Xfn6669pUgAw1a233qqtW7cqJyfHfuTRTz/9pCeeeKJG19cBACvxuiMqYmNjVVpaanYMAHA6f39/9e7dW5LUvn17k9N4tuDgYPXp00fSLxdtBgArsNls6tSpkzp16iTpl9NCAMAd0V4FAAAAAACWQaMCAAAAAABYBo0KAAAAAABgGTQqAAAAAACAZdCoAAAAAAAAlkGjAgAAAAAAWAaNCgAAAAAAYBn1zA4AeKu8vDzFx8e7/DEjIyPrvA1X5nZGZgDWQN2r+eNR9wAA3oxGBWACs3ZAIyMj6/TYZuSua2YA1kDdq91jUvcAAN6MRgVggrS0NLMjXBR3zQ3AfO5aP9w1NwAA7oxrVAAAAAAAAMugUQEAAAAAACyDRgUAAAAAALAMGhUAAAAAAMAyaFQAAAAAAADLoFEBAAAAAAAsg0YFAAAAAACwDBoVAAAAAADAMmhUAAAAAAAAy6BRAQAAAAAALINGBQAAAAAAsAwaFQAAAAAAwDJoVAAAAAAAAMuoZ3YAwBuNGTNGeXl5pjx2ZGSk0tLSLuq+ZuWuS2YA1kDdqx3qHgDAm3FEBWCCvLw8U3Z86/q4ZuQ2a64AOBd1z9qPCQCAlXBEBWCSyMhIZWVlufQx4+Pj67wNV+d2RmYA1kDdqxnqHgDA23FEBQAAAAAAsAwaFQAAAAAAwDJoVAAAAAAAAMugUQEAAAAAACyDRgUAAAAAALAMGhUAAAAAAMAyaFQAAAAAAADLoFEhqaKiQuPHj1dYWJiCgoI0YMAAHTx40OxYgINmzZpp9uzZDssMw1BwcLCWLl1qUqqqlZeXKywsTO+//7592fHjxxUbG6s77rhDlZWVJqbzPHl5eXrmmWckSa+88oqOHDliciLPZBiGvv76az355JOSpDfeeEPl5eUmp/I87lw/3LFeA6idgoICvfDCC0pKStLUqVO1Y8cOsyMBHoVGhaRp06Zp2bJlysnJUUFBgSTp3nvvNTkV8F/79u1TYWGhbrjhBoflO3bsUFlZmTp27GhSsqoFBgZq3LhxSklJkWEYqqio0KBBg+Tn56cFCxbIx4cS5AwHDx7Un/70J0VFRWnKlCmSpEcffVRXXnmlXnjhBRmGYXJCz7Fnzx516tRJXbt21fPPPy9JevDBB3XllVfqzTffNDmdZ3HX+uGu9RpAzZw5c0aPPvqoWrRooeTkZKWnp+vpp5/W//zP/2jo0KE6ceKE2REBj2DNV/lLYNGiRWrXrp0CAwPVq1cvJSUlaeDAgZKkjIwMJScnq1WrVgoJCdELL7ygzMxM7dq1y9zQwP/Jzc2Vr6+vIiIiHJZv3rxZTZo0UfPmzU1KVr3Ro0ersLBQS5Ys0ciRI1VQUKBly5bJz8/P7Gge4cSJE+rZs6eysrLOue3kyZNKTk5WWlqa64N5oCNHjiguLk6bNm0657ajR49q+PDheuedd0xI5rncsX64c70GUL1HH31Ur7zyiv2orrP/NQxD8+bN05AhQ/iAAHACr2hUzJ07V2PHjtXMmTNVUlKiPn36aMaMGYqKilJJSYn27NmjDh062Ndv3bq1goODtWXLFhNTA/+Vm5urNm3ayN/f32H55s2bLf/pXIMGDTR+/Hjdd999ysrKUmZmpoKDg82O5TEWLVqkvLy8Kg+Dnzhxoo4ePerCVJ4pIyNDu3btOu9cG4Yhm82m5ORkVVRUmJDOM7lj/XDneg2gatu3b9frr79e5TpLly7V+vXrXZQI8Fwe36g4duyYkpKSlJGRoW7dusnX11cjRoxQRUWFoqKiVFpaKkkKCQlxuF9oaKj9tptvvlmNGzfWs88+6/L8gPTLjm9+fr4aN27sMKZPn67o6Giz49XI0aNHNWHCBDVp0sTsKB5l9uzZ1R4CX1ZWpiVLlrgokeeaNWuWbDbbBW83DEN79+7VypUrXZjKO7hT/fCEeg3g/ObMmVPl64Ak+fj4cCog4AQe36jIzs5WZWWlbrnlFvuyAwcOSJKioqIUFBQkSSopKXG4X3Fxsf1Tmzlz5ujFF190UWLgXBs2bNCkSZOUl5fnMPz9/S3/Cd38+fP1/PPPa9iwYUpPT+dwSCfbvXt3jS4quHfvXhek8Wz79u2r0fOXuXYed6wf7lyvAVRt7969Nbo+Dq8DgBMYHm7OnDlGmzZtHJY999xzRtOmTe0/X3311cbs2bPtP2/fvt2QZOzcudO+7K233jKmTJlyyfMahmHExcUZkhgePuLi4mr0fPjxxx8NScaGDRvOu/znn3926XOrprkNwzA++eQTIygoyMjOzjbKy8uNsLAw41//+leN7++szAwGwxrD1fXDWTXE1fWausdgMBgMTx015fFHVERERCg/P1/Z2dk6deqUFi5cqGnTpikyMtK+zsiRIzV9+nTt3LlTpaWlSk5OVkJCglq2bGla7ri4OBmGccERFxdX7ToM6464uLgaPxdyc3MVEBBwzhXk16xZo+bNm9f6UOi6PG9qk3vNmjUaPHiw3n77bXXv3t1+rnlKSkqtv1aQ5/qFx/Tp06udP19fXxUWFpqe1d3HmDFjqj3kNygoSEePHjU9qxWHWfVDcl3dc2a9pu4x6jokmZ7B08aaNWtq9Pf7wQcfmJ6VwXD1qMn709q8pnp8o6Jjx4566qmnlJiYqPDwcOXk5Khz586KioqyrzNhwgT17dtX0dHRuuqqq1RRUaH58+ebmBr4r9zcXEVHR6tevXoOy9euXWvZw4i3bt2qPn36KDU1Vf3797cvHzVqlA4cOKDFixebmM6zDBs2TI0aNZKvr2+V6zRt2tSFqTzT6NGj5e/vX+Vhv48//rgCAgJcmMrzuHP9cMd6DaDmunTpom7dul2wae3j46PrrrtOt912m4uTAZ6nXvWruL+UlBSlpKTYf27ZsqUefPBB+8++vr568cUXuQ4FLCk1NfW8y1977TUXJ6m5tm3b6vDhw+csDwgI0P79+01I5LkaN26szz77TAkJCTpw4IBsNpsMw5CPj48qKyt1++236+WXXzY7pkdo3bq1PvnkE/Xt21fl5eXnzPWIESM0ceJEs2O6PXeuH+5YrwHUnM1m09KlS9W7d29t2LDBXv/PatOmjTIzM89pVgKoPY8/ouK3SktLtXv3bocjKqozbNgw/eMf/9CcOXPUt2/fS5gOAGovKipK27dv18yZM/WnP/1JkjR48GCtXLlSS5culZ+fn8kJPUd8fLx27dqlF1980X744n333aecnBzNmjWrRhdZAwC4r0aNGmnt2rVaunSp+vXrp06dOkmSFi5cqLy8PDVv3tzkhIBn8Lp239atWxUUFKTWrVvX+D58xRAAqwsKCtLDDz+shx9+WDabTQsWLDA7ksdq1KiRxo4dq7Fjx8pms/EaAQBepl69eurfv7/99DSbzaa77rrL5FSAZ/G6RkVsbKxKS0vNjgEAAAAAAM6DY1QBAAAAAIBl0KgAAAAAAACWQaMCAAAAAABYBo0KAAAAAABgGTQqAAAAAACAZdCoAAAAAAAAluF1X08KWEVeXp7i4+Nd/piRkZF13oYrczsjMwBroO7V/PGoewAAb0ajAjCBWTugkZGRdXpsM3LXNTMAa6Du1e4xqXsAAG9GowIwQVpamtkRLoq75gZgPnetH+6aGwAAd8Y1KgAAAAAAgGXQqAAAAAAAAJZBowIAAAAAAFgGjQoAAAAAAGAZNCoAAAAAAIBl0KgAAAAAAACWQaMCAAAAAABYBo0KAAAAAABgGTQqAAAAAACAZdCoAAAAAAAAlkGjAgAAAAAAWAaNCgAAAAAAYBk0KgAAAAAAgGXUMzsA4I3GjBmjvLw8Ux47MjJSaWlpF3Vfs3LXJTMAa6Du1Q51DwDgzTiiAjBBXl6eKTu+dX1cM3KbNVcAnIu6Z+3HBADASjiiAjBJZGSksrKyXPqY8fHxdd6Gq3M7IzMAa6Du1Qx1DwDg7TiiAgAAAAAAWAaNCgAAAAAAYBk0KgAAAAAAgGXQqAAAAAAAAJZBowIAAAAAAFgGjQoAAAAAAGAZNCoAAAAAAIBl0KiQVFFRofHjxyssLExBQUEaMGCADh48aHYsAPAKp0+fVmFhoY4cOWJ2FAAAYEHl5eX66aefdPz4cbOjwEVoVEiaNm2ali1bppycHBUUFEiS7r33XpNTAY6aNWum2bNnOywzDEPBwcFaunSpSamqVl5errCwML3//vv2ZcePH1dsbKzuuOMOVVZWmpgOZtu/f7/Gjh2rsLAwNWvWTFdccYVuvPFGLVmyxOxosAB3rh/uWK8BwIpycnKUmJiokJAQXXXVVQoNDdXQoUP1/fffmx0Nl5jXNCoWLVqkdu3aKTAwUL169VJSUpIGDhwoScrIyFBycrJatWqlkJAQvfDCC8rMzNSuXbvMDQ38n3379qmwsFA33HCDw/IdO3aorKxMHTt2NClZ1QIDAzVu3DilpKTIMAxVVFRo0KBB8vPz04IFC+Tj4zUlCL9RUFCg6OhovfTSSyopKbEvX7dunQYMGKDJkyebmA5W4K71w13rNQBYzQcffKCuXbtq2bJl9ub0qVOntGDBAkVHR+vrr782OSEuJWu+yjvZ3LlzNXbsWM2cOVMlJSXq06ePZsyYoaioKJWUlGjPnj3q0KGDff3WrVsrODhYW7ZsMTE18F+5ubny9fVVRESEw/LNmzerSZMmat68uUnJqjd69GgVFhZqyZIlGjlypAoKCrRs2TL5+fmZHQ0mGj58uPbt2yfDMByWn90RmTRpklatWmVGNFiIO9YPd67XAGAVhw4d0l133aWKiopzjqCrrKzUiRMnlJiYqFOnTpmUEJeaxzcqjh07pqSkJGVkZKhbt27y9fXViBEjVFFRoaioKJWWlkqSQkJCHO4XGhqq0tJSbdy4UTfeeKO6d++um266STt27DDj14CXy83NVZs2beTv7++wfPPmzZb/dK5BgwYaP3687rvvPmVlZSkzM1PBwcFmx4KJtm3bphUrVlR56L6Pj49effVVF6aCFblj/XDneg0AVvHmm2/qxIkT53ygcVZlZaWKioo4XdSD1TM7wKWWnZ2tyspK3XLLLfZlBw4ckCRFRUWpfv36kuRw6LEkFRcXKzg4WM2aNVNmZqaCgoK0fPlyTZw4UfPmzXPdLwDolx3f/Px8NW7c2GF5eXm5nnjiCZNS1c7Ro0c1YcIENWnSxOwoMNlXX31V7TqVlZX68ssvXZAG7sCd6ocn1GsAMFt2drZ8fHyq/VAjOztbgwcPdmEyuIzh4ebMmWO0adPGYdlzzz1nNG3a1P7z1VdfbcyePdv+8/bt2w1Jxs6dOx3u99lnnxn333//Jc1rGIYRFxdnSGJ4+IiLi6vxc6Jhw4bG1KlTjb179zqM0NBQ4+OPP3bpc6s2uQ3DMObNm2c0bNjQGDZsmBEREWFUVlbW6v78PTAYnjNcXT+cVUNcXa+pewwGg8Hw1FFTHn9ERUREhPLz85Wdna2YmBi99957mjZtmmJjY+3rjBw5UtOnT1ePHj3UqFEjJScnKyEhQS1btrSvc/bTnLlz57okd1xcnLKysi54e3x8vCRVuQ6s6+y/X03k5+fryJEjSkhIUHh4uMPy4uLiWh9KXN1zqyq1yS1Jy5cv1yOPPKKPP/5YHTp00DXXXKPFixdr0KBBtdpOXTJ7I5vNdsFDJa1g06ZNDtcFOh8fHx/16tVL//73v12U6uJYfa6txKz6Ibmu7jmzXlP3UFfUJ9dhrp3vmWee0ZQpU6pdLyMjQw8++KALEqE6NXl/WpvXVI+/RkXHjh311FNPKTExUeHh4crJyVHnzp0VFRVlX2fChAnq27evoqOjddVVV6miokLz58+3337q1CkNHDhQTz/99DkXxwIutdzcXAUEBJxzBfk1a9aoefPmlj0Ues2aNRo8eLDefvttde/e3X6ueUpKiqW/VhCXXvv27RUdHV3ltzZUVlZq1KhRLkwFK3HX+uGu9RoArGbkyJHy9fW94O02m02BgYEaMmSIC1PBlTy+USFJKSkpOnTokIqKipSenq5t27Y5NCp8fX314osv6uDBgyorK9OSJUvs55ZWVFRoyJAhSkxMVP/+/c36FeDFcnNzFR0drXr1HA+AWrt2rWUvzLZ161b16dNHqampDn83o0aN0oEDB7R48WIT08EK3nzzTQUFBZ3TrLDZbJKkBx54QLfddpsZ0WAyd64f7livAcCKwsPDlZ6eLknn7Cv4+PjIZrNp7ty5atCggRnx4AIef+rHb5WWlmr37t0OjYqqLF68WJmZmTp48KDmz5+vdu3a6eWXX77EKYH/Sk1NPe/y1157zcVJaq5t27Y6fPjwOcsDAgK0f/9+ExLBatq2bat169bpqaee0gcffGD/lPzKK6/U2LFjNWbMGHvTAt7FneuHO9ZrALCqUaNGqWnTpkpJSdGWLVvsy2NiYpSSkqKbbrrJxHS41LyuUbF161YFBQWpdevWNVp/8ODBXEkWAC6BP/zhD3r//ff1888/a8eOHbrxxhu1Z8+eKg/1BAAA3mPAgAFKTEzUf/7zH1133XXKz8+v8fs4uDeva1TExsaqtLTU7BgAgP/TtGlTNW3aVJJoUgAAAAc2m01//OMfJYkmhRfximtUAAAAAAAA90CjAgAAAAAAWAaNCgAAAAAAYBk0KgAAAAAAgGXQqAAAAAAAAJZBowIAAAAAAFgGjQoAAAAAAGAZ9cwOAHirvLw8xcfHu/wxIyMj67wNV+Z2RmYA1kDdq/njUfcAAN6MRgVgArN2QCMjI+v02GbkrmtmANZA3avdY1L3AADejEYFYIK0tDSzI1wUd80NwHzuWj/cNTcAAO6Ma1QAAAAAAADLoFEBAAAAAAAsg0YFAAAAAACwDBoVAAAAAADAMmhUAAAAAAAAy6BRAQAAAAAALINGBQAAAAAAsAwaFQAAAAAAwDJoVAAAAAAAAMugUQEAAAAAACyDRgUAAAAAALAMGhUAAAAAAMAyaFQAAAAAAADLoFEBAAAAAAAsg0YFAAAAAACwDBoVAAAAAADAMmhUAAAAAAAAy6hndgAAQN1UVFQoLy9PGzZs0I8//ihJ+vvf/67IyEh17txZ4eHhJif0HKdPn9aGDRu0ceNG7dixQ5I0efJkRUVFqUuXLvrd735nckIAAAD3R6MCANzU0aNH9eqrr+r111/Xzp07JUn169eXJD3//POqqKiQJCUkJOjxxx9XQkKCaVnd3eHDh5Wenq5Zs2apsLBQkhQQECDpl0aFYRjy9fXV7bffrqSkJN14441mxgUAAHBrnPoBAG7oq6++0vXXX6/k5GS1aNFC8+bN0/bt23Xs2DFJUnl5udavX69Jkybp22+/Ve/evTVkyBAdOnTI5OTu56OPPlJERISmTJmiqKgoLVq0SHv27FF5ebkkqaysTF9//bXGjh2r7Oxsde3aVaNGjbLfDgAAgNqhUQEAbmbevHnq0aOHbDabsrOztXLlSt1zzz1q1aqVbDabpF+OrIiOjtbEiRO1a9cuTZ48WYsXL1ZMTIwKCgpM/g3cxz//+U/169dPTZo00caNG/XJJ59o4MCBat68uX2uGzRooNjYWE2fPl179uzR448/rtdee009evTQ4cOHTf4NAAAA3A+NCgBwI8uXL9f999+v+Ph45eXlqXv37tXe57LLLtMzzzyjrKws7d+/Xz179lRZWZkL0rq3OXPmaNy4cRo4cKDWr1+vqKioau8TEBCg1NRULVu2TFu2bFGfPn10+vRpF6QFAADwHDQqAMBNHD58WMOHD1fbtm314YcfKjAwsFb3v/HGG/XBBx/ohx9+UHJy8iVK6Rl27dqlRx99VD169NCCBQt0+eWX1+r+ffv21dtvv621a9dq2rRplyglAACAZ6JRISk5OVkREREKDg5Ws2bN9OCDD3K4LgDLmThxog4ePKi5c+eqQYMGF7WNHj162E9N2LRpk5MT1t7evXs1adIkDRkyRJL0wQcf6MyZMyanksaNGydJeuutt3TZZZdd1DbuvPNO3XXXXZoyZYr27t3rzHgAAAAejUaFJF9fX82fP1+HDh3S5s2bVVBQoAceeMDsWABgV1ZWpjlz5ujuu+9WZGRknbb1zDPPKCAgQDNnznRSutozDEMTJ05Uy5YtNXnyZC1atEiS9Oc//1lt2rTRf/7zH9OyFRQUaOnSpRo9erRatGhRp209//zzOnPmjDIyMpyUDgAAwPN5TaNi0aJFateunQIDA9WrVy8lJSVp4MCBkqTnnntOUVFRuuyyyxQWFlZiX0IAACAASURBVKbRo0crKyvL3MAA8CsffvihysvL9dBDD9V5WyEhIRoyZIjeeecd045eSE1NVUpKiiorKyXJ/lWqkrR792716NFDBw8eNCXbu+++q8rKSo0cObLO22rRooVuvfVWzZs3zwnJAAAAvINXNCrmzp2rsWPHaubMmSopKVGfPn00Y8aMC14Y7YsvvtD111/v4pQAcGHr169XgwYN1KlTJ6dsr0ePHjp27Ji+//57p2yvNo4fP65nn332grdXVlbq559/1htvvOHCVP+1fv16XXPNNbrmmmucsr0ePXpo9+7dOnDggFO2BwAA4Ok8vlFx7NgxJSUlKSMjQ926dZOvr69GjBihioqK8zYq3n//fc2aNUvp6en2ZfPnz1dMTIxiYmL0xRdfuDI+AEiStm7dqrZt28rX19cp27vhhhvs23W15cuXq7i4uMp1bDab3nrrLRclcrR161b7/DiDmXMNAADgjuqZHeBSy87OVmVlpW655Rb7srOfav22UbF48WI99NBD+vDDD9W+fXtJUnFxsVJTU7V27VqVl5erR48e+uabb5z2ZgEAauLYsWMKDg522vbObuvYsWNO22ZNFRUVVbuOYRjav3+/C9Kcy5PmGgAAwC0ZHm7OnDlGmzZtHJY999xzRtOmTR2Wvfnmm0bDhg2N1atXOyzPzMw0HnvsMfvPffv2NX744YdLF9gwjLi4OEMSg8FgMEwYvr6+pmdgMBgMBoPB8MRRUx5/REVERITy8/OVnZ2tmJgYvffee5o2bZpiY2Pt68yYMUOTJ0/Wp59+qujoaIf7Hzp0SA0bNrT/3LBhQx06dOiS546Li6vygp7x8fGSxEU/AS/x6KOP6q233lJJSUm1R3TZbDYZhlHlOu+++67uuusuffPNN3X+FpHaOnbsmK688kqVlpZWud6UKVP09NNPuyjVf91xxx365ptvtH379mrXrclcv/TSS0pKStL+/fv1u9/9zlkxAaBKNalPcA7m2jWYZ2uryfvTs+vUhMdfo6Jjx4566qmnlJiYqPDwcOXk5Khz584Op3389a9/VWlpqXr06KHAwED7kKRGjRrpyJEj9nWPHDmiRo0aufz3AODdoqOjdfToUW3cuNEp21u5cqX8/f0VERHhlO3VRkBAgJ544okL3u7j46OwsDCnfOvGxYiOjtaOHTu0Z88ep2xv5cqVat68OU0KAACAGvL4RoUkpaSk6NChQyoqKlJ6erq2bdvm0KgwDEOnT59WeXm5w5Ckzp07a9WqVTp58qQOHz6snTt3qnXr1mb9KgC81O23366AgAD97//+b523VVpaqoULF2rQoEG67LLLnJCu9pKTk/W3v/1NNptNNpvN4SiRZs2a6csvvzTtjf3gwYNls9mUkZFR523t3btXn3zyie6++24nJAMAAPAOXtGo+LXS0lLt3r37gl9N+luhoaEaM2aM4uPjddtttyk1NZULaQJwuZCQEA0dOlTz5s2r87dHPPfccyovL9eoUaOclK72bDabpk+frh9//FHJycnq16+fpF9OSdm+fbvatm1rWrYWLVqoX79+evnll1VQUFCnbT399NOy2Wx66KGHnJQOAADA89kMLzvRZ82aNerdu7dKSkpks9nMjnNetTm/h2tUAN7jwIEDioiIUPPmzbV69Wr5+/ufd72qzuFcvXq14uLiNGzYMM2aNetSxq01K517un37dl1//fXq2rWrPvnkE9Wrd/5LOlWVeenSpUpMTNTf//53paSkXMq4AHAOK9VUT8dcuwbzbG01fQ9b0/evXndERWxsrEpLSy3bpACACwkLC9OsWbP0zTffKDExsdZfd7l+/Xr169dP11xzjV588cVLlNIztG7dWi+99JJWrFih+++/X6dPn67V/VesWKEhQ4aoY8eOplwQFAAAwJ15XaMCANzZ7bffrlmzZunTTz9Vhw4dtG7dumrvc+bMGU2fPl3du3dXaGioPv/8c4WEhLggrXsbOXKkpk6dqgULFig2Nlbfffddtfc5ceKEnnjiCd1yyy269tprtXz5cl1++eUuSAsAAOA5aFQAgJsZPny4Pv30Ux09elQxMTHq3bu3Fi9erJ9++sm+zpkzZ7RlyxZNnz5dv//97zVhwgTddtttWrdunVq2bGleeDfz5JNPavHixdq1a5duuOEGJSYm6qOPPlJRUZF9nZMnT2rjxo2aOHGirrnmGk2bNk0PPPCAvvrqK4WFhZmYHgAAwD2d/6RbAICl9ezZU1u3blVaWpoyMjI0aNAgSb9cAFiSAgMDdfLkSUm/nA+Ylpamfv36cdrbRbjjjjsUFxenf/7zn5o9e7aWLl0qSbriiiskSUFBQTp9+rRsNptuvfVWJSUl6aabbjIzMgAAgFujUQEAbio4OFjPPPOMnnzySeXk5Gjjxo3atm2bXn31VT322GOKjIxUly5d1KpVK7Ojur2wsDBNmzZNkyZN0rp167Rx40bt2LFDM2fO1NixY9W+fXvFxMQoPDzc7KgAAABuj0YFALi5evXq6cYbb9SNN94oSXrllVdMTuS56tevr/j4ePuVrV999VVzAwEAAHggrlEBAAAAAAAsg0YFAAAAAACwDBoVAAAAAADAMmhUAAAAAAAAy6BRAQAAAAAALINGBQAAAAAAsAwaFQAAAAAAwDJoVAAAAAAAAMugUQEAAAAAACyDRgUAAAAAALAMGhUAAAAAAMAyaFQAAAAAAADLoFEBAAAAAAAsg0YFAAAAAACwDBoVAAAAAADAMmhUAAAAAAAAy6BRAQAAAAAALKOe2QFgHWPGjFFeXp4pjx0ZGam0tDRTHtsMzDWqY9ZzxNueH/wtug5zjeq4Q90z83l8MeLj482OUKWq5p65di5PmWurz7PEa46zcEQF7PLy8kwpUmY9rpmYa1THjH8rb3x+8LfoOsw1quMOdc+dnk9xcXFmR6hSdXPJXDuPp8y11edZcp+5dAccUQEHkZGRysrKculjukNn9FJgrlEdVz9HvPX5wd+i6zDXqI471D0znseeqCZzz1w7B3PtOrzmOA9HVAAAAAAAAMvgiAoAgKlKS0tVXFwsSaqoqJCvr6/JiQAAAGAmjqjARWnWrJn8/f0VGBiokJAQ9e7dW3v37jU7FgA3YBiGvvrqKw0dOlStW7dWSEiIWrRoIUkKCQlR165d9Y9//EOHDh0yOSkAK2If5L+Kiopks9nOOSd+9+7dstls+n//7/+ZlMzzMNeuw1xDolGBi7Bv3z4VFhZq06ZNKi8v144dO1RUVKQJEyaYHQ2AxW3ZskWdO3dWXFycPvroI0VFRWnq1Kl64403JEnDhw/XqVOn9Le//U1XXXWVJk2apFOnTpmcGoBVsA/iKDc3V/Xr11fbtm0dlq9fv15BQUG69tprTUrmeZhr12GuIdGowEXIzc1VcHCw/vCHP0iSGjVqpPbt22v//v0mJwNgZTNnzlTHjh21e/duZWRkaN++fXrvvff05JNPavjw4ZKk9PR0rV+/Xlu2bNGf//xnTZ48WV26dNG+fftMTg/ACtgHcbRhwwZFRUWpXj3Hs7nXr1+vDh06yMeHXX1nYa5dh7mGRKMCFyE3N1fR0dGy2Ww6c+aMMjMz9a9//UtDhgwxOxoAi0pPT9eoUaOUkJCg7777Tg8++KACAgIuuH67du30zjvvaOnSpcrPz1dcXJx+/vlnFyYGYEXsgzjasGGDoqOjz1m+fv368y7HxWOuXYe5hkSjAhchNzdXq1evVmhoqOrXr69BgwZp9uzZGjZsmNnRAFjQ6tWr9fjjjysxMVFLly5V48aNa3zf/v37a8WKFSosLNS9994rwzAuYVIAVsc+iKONGzee88atsrJSmzZtUnR0tA4ePKiYmBjFxcUpOjpan332mUlJ3R9z7TrMNSQaFZKkd999V926dVNwcPA5hxjhXBs2bNA777yj4uJi7d27V+Hh4frPf/5jdiwAFnTixAkNGzZMLVq00Ny5cy+qxnbp0kWpqan6/PPP7deyAOCd2Af5r7PX6+jQoYPD8ry8PJWXl6tLly5q2LChVq9erezsbL3zzjt68sknTUrr3phr12GucRaNCkkNGzbUI488orS0NLOjWF5+fr6OHDmi9u3bS5KuvPJKjR07Vq+//roqKysl/fLp6a8/2bjzzju1ceNGU/J6ivLycoWFhen999+3Lzt+/LhiY2N1xx132Oce3q1Zs2aaPXu2wzLDMBQcHKylS5eakmnx4sX68ccf9corrygwMPCitzNy5EjFxMTo+eefV0VFhRMT1p4V59kTUffwW+yDOCooKJAkhYaGOixfuHChunTpoubNm8vX19f+lc9lZWW64YYbXJ7TEzDXrsNc4yyvaVQsWrRI7dq1U2BgoHr16qWkpCQNHDhQkpSQkKC77rpLrVq1Mjml9eXm5uqKK66wf5WgJN1+++3av3+/Vq9eLUnq2LGjvvnmG0nSypUrFRISck5XFLUTGBiocePGKSUlRYZhqKKiQoMGDZKfn58WLFjARYVg/wTity/WO3bsUFlZmTp27GhKrtdff13XXnutbr311jptx2azacyYMdq5c6dWrFjhpHS1Z9V59kTUPfwW+yCO/vjHPyokJETTpk1TcXGxDh8+rNdff10zZ87UtGnT7Ovt3LlTXbt2Va9evdS/f38TE7sv5tp1mGuc5RWv8nPnztXYsWM1c+ZMlZSUqE+fPpoxY4aioqLMjuZ2cnNzz5m3xo0bKzY2Vu+9954kqX79+qpfv76OHDmiiRMnaurUqWZE9TijR49WYWGhlixZopEjR6qgoEDLli2Tn5+f2dFgAbm5ufL19VVERITD8s2bN6tJkyZq3ry5yzMdPXpU69at06BBg2Sz2eq8vf79++vyyy/Xl19+6YR0F8eK8+zJqHv4NfZBHAUHB+vjjz/Whg0bFB4erj/84Q9asmSJMjMzFRcXZ1/vmmuu0erVq5Wbm6vRo0ebmNh9Mdeuw1zjLI+/IMOxY8eUlJSk+fPnq1u3bpKkESNG6K9//WuNGxXz58/Xq6++Kkl69tln9ac//emS5bW61NTU8y5ftWqVw8+dO3fWgw8+qAEDBigsLMwV0TxegwYNNH78eN13331q0qSJ1qxZo+DgYLNjwSJyc3PVpk0b+fv7OyzfvHmzaZ/yb9myRZWVlU57/Msvv1zXX3+9qYdxW3GePRl1D7/GPsi5unbtqq+//vqCt588edLe2AsODlZQUJCronkc5tp1mGtIXtCoyM7OVmVlpW655Rb7sgMHDkhSjRoVxcXFSk1N1dq1a1VeXq4ePXrom2++sZ8XhfPr0qWLpkyZonfffdfsKB7n6NGjmjBhgpo0aWJ2FFhIbm6u8vPzz/lGjfLycj3xxBOmZCosLJQkh8O066pFixb6/vvvnba92rLiPHsD6h5qg32Q/9q0aZOSk5Pl6+urM2fOcD22S4i5dh3m2jt4fKOiqKhIv/vd7xyWLVy4UE2bNlXTpk2rvX9OTo66desmPz8/+fn5qWXLltq+fbvatGlzqSJL+qXBUpNDpZ1xOPWv/fqQqrpYvXq1ZsyYUeMr/Nf09/UktZ3r+fPn6/nnn9ewYcOUnp6uESNGXNSceeNcu6vaPEc2bNigSZMmaejQoQ7L27VrV6tP+i/F8yMyMrLG69b0sZ2Z0Yx5lrzzb5G6h+o4Yz/kUu+DOGtfyRViYmL01VdfmR3jgqqbe+baeZhr1/H21xxn/e4ef42KiIgI5efnKzs7W6dOndLChQs1bdo0hx3niooKnThxQqdOnZL0y9fpnThxQoZh6NChQ2rYsKF93YYNG+rQoUOXPHdcXJwMw7jgiIuLq3ad2g5nFKiCggLdfvvtCgkJqdUpMs7+Xaw+ajvXy5cv1yOPPKIPPvhAM2bMUFFRkRYvXlzbfx6vnGt3HbV5jpy9En5CQoLCw8Pt48SJEyouLq7VG2hnPj9ycnIkSUuWLKnR+pKqXScqKko333yz28+zs+faHQZ1j+Hs58hvuWIfxJ3ezLmDquaeuXYu5tp1vPU1pybvT2vzXPP4RkXHjh311FNPKTExUeHh4crJyVHnzp0dTvuYN2+e/P39lZCQoIqKCvn7+8vf31+7d+9Wo0aNdOTIEfu6R44cUaNGjcz4VdxCeHi4li1b5tEXr3K1NWvWaPDgwXr77bfVvXt3+znbKSkpfD0fJP1yOkJAQMA530SxZs0aNW/e3LTD5du1aydfX1+tX7/eKds7fvy4tm7datoV/K06z56IuoeLwT4IAHgOj29USFJKSooOHTqkoqIipaena9u2bQ6Nivvvv/+8HZ+WLVuqc+fOWrVqlU6ePKnDhw9r586dat26tYm/DbzJ1q1b1adPH6Wmpjp89dKoUaN04MCBi/50EZ4lNzdX0dHR5xzmvHbtWlMv8Ojv769u3brpX//6lyoqKuq8vffee0+nT59Wz549nZCu9qw6z56GugcAADz+GhW/VVpaqt27d9f4Gz9CQ0M1ZswYxcfHS/rlitNcSBOu0rZtWx0+fPic5QEBAdq/f78JiWBFF7oS/muvvebiJOd6+OGHdeedd2rp0qW64447Lno7FRUVSktL07XXXqubbrrJiQlrzsrz7EmoewAAwCuOqPi1rVu3KigoqFZHRQwdOlRr167V2rVrTfskDwDc0Z///Ge1a9dOjz32mMNpdLWVlpamTZs26e9//7tXX6AKgPfZt2+fxowZo5ycHMXGxqpbt256/PHH7bc//vjj6tatm/76179WuR1nr+eJzs71Tz/9pPbt26t+/fo6c+aM/Xbm2vnOzvmuXbvUpEkTxcfHq1evXlXeh/n1Dl7XqIiNjVVpaSk7upfA2UJzVmpqqrp27Wr/mWIBeJ/LLrtMc+bMUVFRkQYPHqwTJ07Uehuff/65nnzySfXr109Dhgy5BCkBuCNv2e/47LPP1LNnT7Vo0UJffvmlVq1apaKiIn377bfatGmTjh49qlWrVunUqVPKzc097zacvZ6nOjvXV1xxhb744gt16dLFfhtzfWmcnXNJ6tmzp7KysrRixYoLrs/8eg+va1Tg0vl1oTl58qQ2b95sv41iAXiv9u3ba9asWVqxYoV69+6tvXv31uh+hmHorbfeUp8+fXTttdfqrbfeoskMwM4T9zuysrLUsGFDxcfHq0WLFurfv7+ysrIUFxenpk2bqn79+pKkevXqydfXV2vXrtXNN98sSbr55pu1bt26827X2et5gqrmun79+g7f+ic5fw69aa7PqmrOJWnlypXq1q2bXnrppQtug/n1HjQqUGvnKzJnl58tNG+88Ybuu+8++30oFoB3e+CBBzR//nzl5uYqIiJC06dPv+BXPRuGoa+++kq33HKLhg0bpi5dumjlypW64oorXJwagFVU9wbHU/Y7unfvrk6dOtl/t1dffVXHjh1TYGCgfZ0tW7bo4MGDuu6661RcXKzg4GBJUkhIyAVPsXP2ep6gJnP9a8x13VU151deeaW2bdumlStX6vPPP9eWLVvOuw3m13vQqECtna/IGIZhLzSnT59Wdna2wwXvKBYA7r77bn377bfq0qWLJkyYoKuuuko33XSTxo0bpxdeeEGSdM899+j3v/+94uLitG7dOqWnp+vLL7/ka6EBL1fVGxxP2u/YsWOHWrVqJUnau3evDhw44PCVyIcPH9bo0aM1e/ZsSb9c9L20tFTSLxeMDw0NPe92nb2eJ6hurn+Lua67qubcz89PDRo0UL169dSnTx9t3br1vNtgfr0HjQpc0M8//6z4+HiHMXjw4HOKzFVXXaXNmzfbC828efPOOY+cYgFAklq1aqUVK1Zoy5Yt+stf/qKysjK9/PLLSk5OlvTLYZ/XXXed3njjDf3000967LHH5OPDSxXg7ap6g+NJ+x3fffedIiIiVFFRIR8fH61YscJ+esuZM2d0zz336B//+IeaNm0qSYqJidEXX3wh6Zfr+XTp0kVnzpw55xty6rKep6pqrs+Hua67qua8rKzMvt7XX3+t1q1bM79ejr0/XFDTpk2VlZXlMN59991ziowkh0Lzww8/6LXXXlPv3r313Xff6eWXX6ZYAHDQrl07paWlKTc3V8eOHVNZWZmOHz+uffv26cMPP9Tw4cMVEBBgdkwAFlHVGxxP2u84+3uePHlSRUVF+uKLL9SxY0dJ0uLFi5Wbm6vk5GTFx8dr7dq19m+m6Natm3x8fNSpUyft2rVLTz/9tMN267Kep6pqrk+fPq2bb75ZmzdvVkJCgnJycphrJ6hqzletWqUOHTooNjZWzZo1U+fOnZlfL1fP7ABwP999951iYmLsRaawsFAbN27UuHHjJEnTp0+3r9u1a1c9+uijkmQvFjfccAPFAoCdr6/vBc8JBgDp3H2PL774wiP3O5588kn7/3/77bdatGiR/UOhu+66S3fdddc590lPT3f4efPmzU5dz1NVNdeXXXaZPv/883Puw1zXTVVzfuutt+rWW291WJ/59W40KlBrvy0ykjRgwIDzHp69evVq+/9TLAAAwMWo6g3Or3nafsegQYNqfZ8BAwY4dT1vwVy7XnVzzvx6NxoVcJCXl6f4+PiLuu/MmTMv+jEjIyMv6r7urC5zXZfH9Ma5dleufo546/ODv0XXYa5Rndo8Ry52v+O3j1fb54cZz2NPVJO5Z66dg7l2HV5znIdGBezM+qOKjIz0uj9o5hrVMePfyRufH/wtug5zjeq4Q93jueQ81c09c+08zLXr8JrjPDbDMAyzQ8DR2W5mVlZWndYBAAAAAOBSq+l72Jq+f+VbPwAAAAAAgGXQqAAAAAAAAJZBowIAAAAAAFgGjQoAAAAAAGAZNCoAAAAAAIBl0KgAAAAAAACWQaMCAAAAAABYBo0KAAAAAABgGTQqAAAAAACAZdCoAAAAAAAAlkGjAgAAAAAAWAaNCgAAAAAAYBk0KgAAAAAAgGXQqAAAAAAAAJZBowIAAAAAAFgGjQoAAAAAAGAZNCoAAAAAAIBl0KgAAAAAAACWQaMCAAAAAABYBo0KAAAAAABgGTQqAAAAAACAZdCoAAAAAAAAlkGjAgAAAAAAWAaNiipUVFRo/PjxCgsLU1BQkAYMGKCDBw+aHQsAAAAAAI9Fo6IK06ZN07Jly5STk6OCggJJ0r333mtyKgAAAAAAPBeNCklff/21EhIS1KRJE4WGhmrgwIGSpIyMDCUnJ6tVq1YKCQnRCy+8oMzMTO3atcvcwAAAAAAAeCivb1S8//776tevn0aOHKk9e/Zo7969GjFihEpKSrRnzx516NDBvm7r1q0VHBysLVu2mJgYAAAAAADPVc/sAGY6evSoHnroIaWnp2vAgAGSJD8/PyUkJGjv3r2SpJCQEIf7hIaGqrS09JJn27GnUBOmZ1R5u6Qq1wEAAAAA4FKryfvTs+vUhFc3KrKzs2Wz2XT33Xefc1tQUJAkqaSkxGF5cXGxgoODL2muyMhIRUZGalryyAuuc6Lwe0mqch0AAAAAAC61mrw/PbtOTdgMwzDqnMpNvf3223r22We1bdu2897eokULTZw4UcOGDZMk7dixQ61bt9bOnTvVsmVLFyYFAAAAAMA7eHWj4rvvvlNkZKSWLFmi2267TaWlpcrJyVFCQoIkaerUqXr77beVmZmpRo0aafjw4SorK1NmZuYlz8YpHQAAAAAAT1LTMwK8ulEhSXPnztVzzz2nffv2KSgoSMOGDdPUqVMlSRUVFUpOTtacOXN08uRJ9ezZUxkZGWrcuLHJqQEAAAAA8Exe36gAAAAAAADW4fVfTwoAAAAAAKyDRgUAAAAAALAMGhUAAAAAAMAyaFQAAAAAAADLoFEBAAAAAAAsg0YFAAAAAACwDBoVAAAAAADAMmhUAAAAAAAAy6BRAQAAAAAALINGBQAAAAAAsAwaFQAAAAAAwDJoVAAAAAAAAMugUQEAAAAAACyDRgUAAAAAALAMGhUAAAAAAMAyaFQAAAAAAADLoFEBAAAAAAAsg0YFAAAAAACwDBoVAAAAAADAMmhUAAAAAAAAy6BRAQAAAAAALINGBQAAAAAAsAwaFQAAAAAAwDJoVAAAAAAAAMugUQEAAAAAACyDRgUAAAAAALAMGhUAAAAAAMAyaFQAAAAAAADLoFEBAAAAAAAsg0YFAAAAAACwDBoVAAAAAADAMmhUAAAAAAAAy6BRAQAAAAAALINGBQAAAAAAsAwaFQAAAAAAwDJoVAAAAAAAAMugUQEAAAAAACyDRgUAAPj/7d1/bJWHfe/xDzgpYYoNXANxsoS6cUq6EKhdYMzOpUDahNGhSIPRNdqCuoSRdD86BmNGYtq6dK1MEtGAVK7kam1ofNEGpFrWaZfdlAgrt+J67RKSsd0pIhB+dFUBx/YpoSPU+P5R1ZqTFNwu9nni83pJSPg538fne+C/t57nOQAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVCTp7+/Pxo0bM23atFRXV2flypU5e/ZsudcCAACAiiNUJGlra8vTTz+drq6unDp1Kkly3333lXkrAAAAqDzjBgYGBsq9xGjYvXt3PvvZz+bYsWNpaWnJ7bffnpMnT2bPnj1573vfmz/9PlydFQAAGY5JREFU0z/NAw88kCR55ZVXcsstt+TYsWOpr68v7+IAAABQQSriioqdO3dmw4YN2bFjR/r6+rJ8+fJs3749TU1N6evry4kTJzJ37tzB+YaGhtTU1OSll14q49YAAABQecZ8qDh//nzWr1+f9vb2LFy4MFVVVVmzZk36+/vT1NSUUqmUJJk0adKQ8yZPnjz4WkdHR5qbm9Pc3Jz9+/eP+M7r1q3LunXr/sszAAAA8G5zVbkXGGmdnZ25dOlSli1bNnjszJkzSZKmpqZcc801SZK+vr4h5/X29qampia9vb3ZunVrDh48mHPnzmXJkiV54YUXUlVVNWI7Hzp0KJ2dndm2bdsVZ4czAwAAAOU23CdPjPlQcfr06UyfPn3IsV27dqWuri51dXVJkhkzZuT5559PY2NjkuTo0aMplUqZM2dOurq6snDhwkyYMCETJkxIfX19XnnllcycOXNE9160aFEOHDjwE19fvHhxklx2BgAAAN5txvytH7NmzcqRI0fS2dmZN954I7t27UpbW9tglEiStWvXZsuWLTl27FhKpVJaW1uzdOnS1NfXp7u7O1OmTBmcnTJlSrq7u8vxUQAAAGDMG/NXVMybNy+bN2/OihUrUlVVlXvvvTcLFixIU1PT4MymTZvS09OT+fPn58KFC7nrrrvS0dGRJKmtrU1PT8/gbE9PT2pra0f9cwAAAEAlqJivJ/3P6uvr8+ijj2bVqlVXnO3t7c2dd96ZgwcP5vXXX8+iRYty6NChEX1GxXBu63DrBwAAAGPRmL+i4s1KpVKOHz8+5IqKy5k8eXLWrVs3GAa2bt06opECAAAAKlnFhYrDhw+nuro6DQ0Nwz5n9erVWb169QhuBQAAACQVGCpaWlpSKpXKvQYAAADwNsb8t34AAAAA7x5CBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQkWS/v7+bNy4MdOmTUt1dXVWrlyZs2fPlnstAAAAqDhCRZK2trY8/fTT6erqyqlTp5Ik9913X5m3AgAAgMpTMaFi9+7dmT17dq699trcfffdWb9+fVatWpUkaW9vT2tra26++eZMmjQpjzzySPbt25dXX321vEsDAABAhamIULFz585s2LAhO3bsSF9fX5YvX57t27enqakpfX19OXHiRObOnTs439DQkJqamrz00ktl3BoAAAAqz5gPFefPn8/69evT3t6ehQsXpqqqKmvWrEl/f3+amppSKpWSJJMmTRpy3uTJkwdf++hHP5qpU6fmL/7iL0Z9fwAAAKgkV5V7gZHW2dmZS5cuZdmyZYPHzpw5kyRpamrKNddckyTp6+sbcl5vb29qamqSJE888US+8Y1vDD6/AgAAABgZYz5UnD59OtOnTx9ybNeuXamrq0tdXV2SZMaMGXn++efT2NiYJDl69GhKpVLmzJmTJLnxxhtHd+n8KLCMGzfuinPDmQEAAIByGxgYGNbcmA8Vs2bNypEjR9LZ2Znm5ubs3bs3bW1taWlpGZxZu3ZttmzZkiVLlqS2tjatra1ZunRp6uvry7b3okWLcuDAgZ/4+uLFi5PksjMAAADwbjPmQ8W8efOyefPmrFixIlVVVbn33nuzYMGCNDU1Dc5s2rQpPT09mT9/fi5cuJC77rorHR0dZdwaAAAAKtOYf5hmkjz88MPp7u7O6dOns23btrz88stDQkVVVVUee+yxnD17Nt///vfzta99LVOnTi3jxgAAAFCZxvwVFW9WKpVy/PjxIaHiSu6///50dXXlwoUL6erqyte//vUR3BAAAAAqV8WFisOHD6e6ujoNDQ3DPufLX/7yCG4EAAAA/FjFhYqWlpaUSqVyrwEAAAC8jYp4RgUAAADw7iBUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVAAAAACFIVQAAAAAhSFUAAAAAIUhVCTp7+/Pxo0bM23atFRXV2flypU5e/ZsudcCAACAiiNUJGlra8vTTz+drq6unDp1Kkly3333lXkrAAAAqDwVEyp2796d2bNn59prr83dd9+d9evXZ9WqVUmS9vb2tLa25uabb86kSZPyyCOPZN++fXn11VfLuzQAAABUmIoIFTt37syGDRuyY8eO9PX1Zfny5dm+fXuamprS19eXEydOZO7cuYPzDQ0NqampyUsvvVTGrQEAAKDyjPlQcf78+axfvz7t7e1ZuHBhqqqqsmbNmvT396epqSmlUilJMmnSpCHnTZ48OaVSKf/0T/+UO+64Ix/+8Idz55135ujRo+X4GAAAAFARrir3AiOts7Mzly5dyrJlywaPnTlzJknS1NSUa665JknS19c35Lze3t7U1NTkhhtuyL59+1JdXZ2///u/z5/92Z/lySefHL0PAAAAABVkzIeK06dPZ/r06UOO7dq1K3V1damrq0uSzJgxI88//3waGxuTJEePHk2pVMqcOXNy/fXXD573nve8J1ddNTr/ZJ2dnRk3btwV54YzAwAAAOU2MDAwrLkxHypmzZqVI0eOpLOzM83Nzdm7d2/a2trS0tIyOLN27dps2bIlS5YsSW1tbVpbW7N06dLU19cPzrz++uvZtGlTdu7cOSp7L1q0KAcOHPiJry9evDhJLjsDAAAA7zZjPlTMmzcvmzdvzooVK1JVVZV77703CxYsSFNT0+DMpk2b0tPTk/nz5+fChQu566670tHRMfj6G2+8kVWrVuVP/uRPMmvWrHJ8DAAAAKgI4waGe+3FGFJfX59HH3108OtJL6e/vz+//uu/nl/+5V/OmjVrRmG74V0t4YoKAAAAxqIx/60fb1YqlXL8+PEhV1Rczp49e7Jv3750dHRk8eLF+f3f//0R3hAAAAAq15i/9ePNDh8+nOrq6jQ0NAxr/hOf+EQ+8YlPjPBWAAAAQFKBoaKlpSWlUqncawAAAABvo+Ju/QAAAACKS6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqEjS2tqaWbNmpaamJjfccEN++7d/O6+99lq51wIAAICKI1QkqaqqSkdHR7q7u/Piiy/m1KlT+a3f+q1yrwUAAAAVp2JCxe7duzN79uxce+21ufvuu7N+/fqsWrUqSfL5z38+TU1NufrqqzNt2rT83u/9Xg4cOFDehQEAAKACVUSo2LlzZzZs2JAdO3akr68vy5cvz/bt29PU1PS28/v378+cOXNGeUsAAABgzIeK8+fPZ/369Wlvb8/ChQtTVVWVNWvWpL+//21DxVNPPZUvfelL2bZt2+Cxjo6ONDc3p7m5Ofv37x/N9QEAAKCiXFXuBUZaZ2dnLl26lGXLlg0eO3PmTJK8JVTs2bMnDz74YP72b/82H/rQh5Ikvb292bp1aw4ePJhz585lyZIleeGFF1JVVTV6HwIAAAAqxJgPFadPn8706dOHHNu1a1fq6upSV1c3eOwrX/lKNmzYkK9//eu54447Bo93dXVl4cKFmTBhQiZMmJD6+vq88sormTlz5oju3dnZmXHjxl1xbjgzAAAAUG4DAwPDmhvzoWLWrFk5cuRIOjs709zcnL1796atrS0tLS2DM9u3b8+f//mf5x/+4R8yf/78Ied3d3dnypQpgz9PmTIl3d3dI773okWLLvtAz8WLFyeJh34CAAAwpoz5UDFv3rxs3rw5K1asSFVVVe69994sWLBgyG0ff/AHf5CrrroqS5YsGXLuuXPnUltbm56ensFjPT09qa2tHbX9AQAAoJKM+YdpJsnDDz+c7u7unD59Otu2bcvLL788JFQMDAzk4sWLOXfu3JA/SbJgwYI899xzuXDhQl577bUcO3YsDQ0N5fooAAAAMKaN+Ssq3qxUKuX48eM/8atJ32zy5MlZt27d4K0WW7du9SBNAAAAGCEVFyoOHz6c6urqn+qqiNWrV2f16tUjuBUAAACQVGCoaGlpSalUKvcaAAAAwNuoiGdUAAAAAO8OQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYQgUAAABQGEIFAAAAUBhCBQAAAFAYV5V7ASrDunXrcujQobK8d2NjYx5//PGyvDcAAAA/HVdUMCoOHTpUllBRrvcFAADgZ+OKCkZNY2NjDhw4MKrvuXjx4lF9PwAAAP5rXFEBAAAAFIZQAQAAABSGUAEAAAAUhlABAAAAFIZQAQAAABSGUAEAAAAUhq8npZB6e3vzrW99Ky+88EJ6enpSVVWVhoaGzJ07N7fffnvGj39rY3vmmWfy4osv5o/+6I/KsDEAAADvBKEiyV/91V/li1/8Yl588cWcP38+P/zhD8u9UsX69re/nS984QvZs2dPLl68mCS5+uqr09/fn0uXLiVJbr755jz44IP51Kc+lerq6iQ/ihT33HNPZs6cmd/93d/NxIkTy/YZAAAA+Nm59SPJlClT8ju/8zt5/PHHy71KxfrBD36QDRs25Bd/8Rfzd3/3d3nooYfyzDPPpLu7O2+88UYuXryYf/u3f8tXvvKV3HTTTWltbc3s2bPz7LPPDkaK97///dm/f79IAQAA8C5WMVdU7N69O5/97Gdz7NixtLS05Pbbb8/JkyezZ8+eLF26NEly4MCB8i5ZoXp7e/Oxj30sBw8ezKc+9am0tbWlpqZmyMz48eNz66235tZbb80nP/nJfPOb38z999+fj3zkI7n66qvzgQ98IM8++2ymTp1apk8BAADAO6EirqjYuXNnNmzYkB07dqSvry/Lly/P9u3b09TUVO7VKt7Fixdzzz335Nvf/nb27t2bHTt2vCVSvJ077rgjjz32WMaPH5+LFy/m05/+tEgBAAAwBoz5UHH+/PmsX78+7e3tWbhwYaqqqrJmzZr09/cPO1R0dHSkubk5zc3N2b9//whvXFkeffTRPPfcc/nyl7+clStXDvu8Z555Jh//+Mdz2223Ze7cudm4cWO++93vjuCmAAAAjIYxf+tHZ2dnLl26lGXLlg0eO3PmTJIMK1T09vZm69atOXjwYM6dO5clS5bkhRdeSFVV1YjtXClOnjyZz3zmM1m1alV+8zd/c9jn/ednUjz77LN57bXX8sEPfjB//Md/nCeffHIENwYAAGCkjflQcfr06UyfPn3IsV27dqWuri51dXVXPL+rqysLFy7MhAkTMmHChNTX1+eVV17JzJkzR2rlJD8KLOPGjbvi3HBmimLRokVDfm5vb88Pf/jDbNmyZdi/482RYurUqZk6dWoeeuihfPGLX8xjjz2W6667bsg5w/23BAAAYOQMDAwMa27Mh4pZs2blyJEj6ezsTHNzc/bu3Zu2tra0tLQMzvT39+fixYt54403kiT/8R//kSSZMGFCuru7M2XKlMHZKVOmpLu7e8T3XrRo0WUf7rl48eIk754HgP543//sq1/9apYtW5b3ve99w/odbxcpfuyhhx7K448/nr/+67/Opz/96SHnXenfEgAAgOIY88+omDdvXjZv3pwVK1bkxhtvTFdXVxYsWDDkto8nn3wyEydOzNKlS9Pf35+JEydm4sSJOX78eGpra9PT0zM429PTk9ra2nJ8lDHle9/7Xk6cOJGPfvSjw5q/XKRIkltvvTU///M/n3/8x38ciXUBAAAYJWM+VCTJww8/nO7u7pw+fTrbtm3Lyy+/PCRUfPKTn8zAwMBb/tTX12fBggV57rnncuHChbz22ms5duxYGhoayvhpxobDhw8nSRobG684e6VI8WONjY3553/+53d0TwAAAEbXmL/1481KpVKOHz8+7G/8mDx5ctatWzd468LWrVs9SPMdcP311+cP//APc8stt1x27syZM/nVX/3VK0aKJPn4xz+ef//3f3+nVwUAAGAUVVyoOHz4cKqrq3+qqyJWr16d1atXj+BWlee2227L1q1brzg3bdq07Nq1Ky0tLZeNFEn8HwEAAIwBFRcqWlpaUiqVyr0GP4V77rmn3CsAAAAwSiriGRUAAADAu4NQAQAAABSGUAEAAAAUhlABAAAAFIZQAQAAABSGUAEAAAAUhlABAAAAFMZV5V6AynHo0KEsXrx41N+zsbFxVN8TAACAn50rKhgVjY2NP1MwOHriu2/795F+XwAAAMrDFRWMiscff/xnOm/Tlva0ta59y98BAAAYm1xRAQAAABSGUAEAAAAUhlABAAAAFIZQAQAAABSGUAEAAAAUhlABAAAAFIZQAQAAABSGUAEAAAAUhlABAAAAFIZQAQAAABSGUAEAAAAUhlABAAAAFIZQAQAAABSGUAEAAAAUhlDBmHXgwIHMmjUrt9xyS9asWZP+/v5yrwQAAMAVCBWMSZcuXcqaNWuyZ8+eHDlyJKVSKR0dHeVeCwAAgCsQKhiTvvWtb+WGG27IbbfdliR54IEH8tRTT5V5KwAAAK5EqGBMOnXqVG666abBn2fMmJGTJ0+WcSMAAACG46pyLwA/1n/pUv7n33wjr5//wZDj/6Pj6bf9+y813ZamWe9/2981MDCQcePGDfkZAACA4hMqKIyq8eMz83035m/+9/8Zcvz4d773lr9f+3MT8wu3vPcn/q6bbropJ06cGPz55MmTufHGG9/hjQEAAHinufWDQpn/wQ/kuqlTrjh394fn55oJ7/mJr8+bNy/f+c538q//+q9Jkr/8y7/MihUr3rE9AQAAGBlCBYVSNX58lt/ZfNmZ66fXZt7smZf/PVVV+dKXvpRf+7VfS0NDQ6699trcd9997+SqAAAAjAC3flA473/fjfmFW2bk/x058bavL/9Ic8aPv3Jju/POOwevqAAAAODdwRUVl9Hf35+NGzdm2rRpqa6uzsqVK3P27Nlyr1URPrbkl1L1NjFi1sz6NMy4oQwbAQAAMBqEistoa2vL008/na6urpw6dSpJ3D4wSqb9t8lpnjtryLGqqvH52OJfKtNGAAAAjAahIsk3v/nNLF26NNddd10mT56cVatWJUna29vT2tqam2++OZMmTcojjzySffv25dVXXy3vwhXiIy0fys9NnDD483+fNzu1U2rKuBEAAAAjreJDxVNPPZV77rkna9euzYkTJ3Ly5MmsWbMmfX19OXHiRObOnTs429DQkJqamrz00ktl3LhyTLxmQu5eOD/Jj76OdElzU5k3AgAAYKRV9MM0X3/99Tz44IPZtm1bVq5cmSSZMGFCli5dmpMnTyZJJk2aNOScyZMnp1QqjfhuR098N5u2tF/29SSXnRlLzp3/QT7z+BPlXgMAAICfUVvr2mHNVXSo6OzszLhx4/Ibv/Ebb3mturo6SdLX1zfkeG9vb2pqRv72g5tnXH/Z/8T/+792JRn+f/S72XdPd+e6qVOG9U0fAAAAvLtVdKg4e/ZspkyZknHjxr3ltcmTJ2fGjBl5/vnn09jYmCQ5evRoSqVS5syZM6J7/fj9/qszY8X102vLvQIAAACjZNzAwMBAuZcol3/5l39JY2Njvva1r+VXfuVXUiqV0tXVlaVLlyZJPve5z+WrX/1q9u3bl9ra2jzwwAP5/ve/n3379o34bpVySwcAAACVYbh3BFR0qEiSnTt35vOf/3y+853vpLq6Ovfff38+97nPJUn6+/vT2tqaJ554IhcuXMhdd92V9vb2TJ06tcxbAwAAwNhU8aECAAAAKA5PJwQAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACkOoAAAAAApDqAAAAAAKQ6gAAAAACuP/A47jQ2MUR8tLAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x22fb53d5be0>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc_list = create_grover_circuit([2], nbit, b_max)\n",
+    "my_style = {'usepiformat': True, 'cregbundle': True,'compress': True }\n",
+    "qc_list[0].draw(output=\"mpl\", style=my_style, plot_barriers=False )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also need a helper function to simultaneously run the quantum circuits that are returned by the above functions, as below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_grover(qc_list, number_grover_list, shots_list, backend):\n",
+    "    \"\"\"\n",
+    "        Run the quantum circuits returned by create_grover_circuit()\n",
+    "            qc_list: list of quantum circuits\n",
+    "            numebr_grover_list: list of number of Grover operators\n",
+    "            shots_list:  list of number of shots\n",
+    "            backend: name of backends\n",
+    "        \n",
+    "        Return:\n",
+    "            hit_list: list of count of obserbving \"1\" for qc_list\n",
+    "    \"\"\"\n",
+    "    hit_list = []\n",
+    "    for k in range(len(number_grover_list)):\n",
+    "        job = execute(qc_list[k], backend=backend, shots=shots_list[k])\n",
+    "        lapse = 0\n",
+    "        interval = 0.00001\n",
+    "        time.sleep(interval)\n",
+    "        while job.status().name != 'DONE':\n",
+    "            time.sleep(interval)\n",
+    "            lapse += 1\n",
+    "        counts = job.result().get_counts(qc_list[k]).get(\"1\", 0)\n",
+    "        hit_list.append(counts)\n",
+    "    return hit_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Post processing to estimate the amplitude from results of various Grover Circuits\n",
+    "\n",
+    "At the heart of the techniques to estimate the amplitude without QFT and controlled Grover operators is a post processing function that combines the results of running Grover circuits with various number of iterations. Suppose we run Grover operators for $\\{m_0, m_1, \\ldots, m_M\\}$ times and for each of the $m_k$ run, we repeat it for $N_k$ times (i.e., the number of shots) of which we observe $h_k$ times of \"good\" states. Because the probability of observing \"good\" states is $\\sin^2((2m_k + 1)\\theta_a)$, the likelihood of observing $h_k$ times of \"good\" states is \n",
+    "$$\n",
+    "L_k(h_k;\\theta_a) = \\left( \\sin^2((2m_k + 1)\\theta_a) \\right)^{h_k} \\left( \\cos^2((2m_k + 1)\\theta_a) \\right)^{N_k - h_k}. \n",
+    "$$\n",
+    "\n",
+    "When we have observation of good states as $\\mathbf{h} = \\{h_0, h_1, \\ldots, h_M\\}$, the likelihood function becomes\n",
+    "$$\n",
+    "L(\\mathbf{h};\\theta_a) = \\prod_{k=0}^M L_k(h_k;\\theta_a). \n",
+    "$$\n",
+    "\n",
+    "From this, we can find an optimal value of $\\tilde{\\theta}_a$  that maximizes the above likelihood function, namely, \n",
+    "$$\n",
+    "\\tilde{\\theta}_a = \\mbox{arg}~\\mbox{max}_{\\theta} L(\\mathbf{h};\\theta_a).\n",
+    "$$\n",
+    "\n",
+    "\n",
+    "The function below is to compute such an optimal $\\tilde{\\theta}_a$. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "run_control": {
+     "marked": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def calculate_theta(hit_list, number_grover_list, shots_list):\n",
+    "    \"\"\"\n",
+    "        calculate optimal theta values\n",
+    "            hit_list: list of count of obserbving \"1\" for qc_list\n",
+    "            numebr_grover_list: list of number of Grover operators        \n",
+    "            shots_list: list of number of shots\n",
+    "\n",
+    "        Return:\n",
+    "            thetaCandidate_list: list of optimal theta\n",
+    "    \"\"\"\n",
+    "\n",
+    "    small = 1.e-15  # small valued parameter to avoid zero division\n",
+    "    confidenceLevel = 5  # confidence level to determine the search range\n",
+    "\n",
+    "    thetaCandidate_list = []\n",
+    "    rangeMin = 0.0 + small\n",
+    "    rangeMax = 1.0 - small\n",
+    "    for igrover in range(len(number_grover_list)):\n",
+    "\n",
+    "        def loglikelihood(p):\n",
+    "            ret = np.zeros_like(p)\n",
+    "            theta = np.arcsin(np.sqrt(p))\n",
+    "            for n in range(igrover + 1):\n",
+    "                ihit = hit_list[n]\n",
+    "                arg = (2 * number_grover_list[n] + 1) * theta\n",
+    "                ret = ret + 2 * ihit * np.log(np.abs(np.sin(arg))) + 2 * (\n",
+    "                    shots_list[n] - ihit) * np.log(np.abs(np.cos(arg)))\n",
+    "            return -ret\n",
+    "\n",
+    "        searchRange = (rangeMin, rangeMax)\n",
+    "        searchResult = optimize.brute(loglikelihood, [searchRange])\n",
+    "        pCandidate = searchResult[0]\n",
+    "        thetaCandidate_list.append(np.arcsin(np.sqrt(pCandidate)))\n",
+    "        perror = CalcErrorCramérRao(igrover, shots_list, pCandidate, number_grover_list)\n",
+    "        rangeMax = min(pCandidate+confidenceLevel*perror,1.0 - small)\n",
+    "        rangeMin = max(pCandidate-confidenceLevel*perror,0.0 + small)\n",
+    "    return thetaCandidate_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Remark about the Cramér-Rao bound\n",
+    "\n",
+    "The advantages offered by Amplitude Amplification without QFT and Controlled Grover operators depend on the design of sequences of number of Grover iterations $\\{m_k\\}$ and number of shots $\\{N_k\\}$ for each run of iteration. The Cramér-Rao inequality provides the lower bound of the error of estimating the amplitude by the following\n",
+    "\n",
+    "$$\n",
+    "\\mbox{var}(\\tilde{a}) = \\mathbb{E}[(\\tilde{a} - \\mathbb{E}[\\tilde{a}])^2] \\ge \\frac{\\|1 + b'(a)\\|^2}{\\mathcal{I}(a)},\n",
+    "$$\n",
+    "where $b'(a)$ is the derivative of $b(a) \\equiv \\mathbb{E}[\\tilde{a} - a]$ with respect to $a$, and $\\mathcal{I}(a)$ is the so-called *Fisher information* defined as \n",
+    "\n",
+    "$$\n",
+    "\\mathcal{I}(a) = \\mathbb{E}\\left[ \\left( \\frac{\\partial \\ln{L(x;a)} }{\\partial a} \\right)^2\\right].\n",
+    "$$\n",
+    "\n",
+    "With regards to $\\{m_k\\}$ and $\\{N_k\\}$, the total number of oracle calls is given as \n",
+    "$$\n",
+    "N_{\\mbox{orac}} = \\sum_{k=0}^{M} N_k (2 m_k + 1),\n",
+    "$$\n",
+    "and the Fisher information is given as\n",
+    "$$\n",
+    "\\mathcal{I}(a) = \\frac{1}{a(1-a)} \\sum_{k=0}^{M} N_k(2m_k + 1)^2 \\le \\frac{1}{a(1-a)} N^2_{\\mbox{orac}}.\n",
+    "$$\n",
+    "\n",
+    "Thus, the error $\\tilde{\\epsilon} = \\mathbb{E}[(\\tilde{a} - a)^2]$ satisfies \n",
+    "$$\n",
+    "\\tilde{\\epsilon} \\approx \\frac{1}{\\mathcal{I}(a)^{1/2}} \\ge \\frac{\\sqrt{a(1-a)}}{N_{\\mbox{orac}}}\n",
+    "$$\n",
+    "\n",
+    "The bound above gives the lower bound of approximation error with regards to the approximated value $a$ and the total number of quantum oracle calls. Note that $\\tilde{\\epsilon} \\approx \\sqrt{a(1-a)}N_{\\mbox{orac}}^{1/2}$ for classical case, which is quadratically worse than the quantum case. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing the algorithm with simulators\n",
+    "\n",
+    "Let us run the algorithm with simulators"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#setting the number of shots and Grover operators.\n",
+    "\n",
+    "shots_list = [100, 100, 100, 100, 100, 100, 100]  # list of number of shots\n",
+    "number_grover_list = [0, 1, 2, 4, 8, 16, 32]  # list of number of Grover operators\n",
+    "if len(shots_list) != len(number_grover_list):\n",
+    "    raise Exception(\n",
+    "        'The length of shots_list should be equal to the length of number_grover_list.'\n",
+    "    )\n",
+    "\n",
+    "backend = Aer.get_backend('qasm_simulator')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also need functions to evaluate the accuracy against the true value. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def CalcErrorCramérRao(M, shot_list, p0, number_grover_list):\n",
+    "    \"\"\"\n",
+    "        calculate Cramér-Rao lower bound\n",
+    "            M: upper limit of the sum in Fisher information \n",
+    "            shots_list:  list of number of shots\n",
+    "            p0: the true parameter value to be estimated\n",
+    "            numebr_grover_list: list of number of Grover operators        \n",
+    "\n",
+    "        Return:\n",
+    "            square root of Cramér-Rao lower bound:  lower bound on the standard deviation of unbiased estimators\n",
+    "    \"\"\"\n",
+    "    FisherInfo = 0\n",
+    "    for k in range(M + 1):\n",
+    "        Nk = shot_list[k]\n",
+    "        mk = number_grover_list[k]\n",
+    "        FisherInfo += Nk / (p0 * (1 - p0)) * (2 * mk + 1)**2\n",
+    "    return np.sqrt(1 / FisherInfo)\n",
+    "\n",
+    "\n",
+    "def CalcNumberOracleCalls(M, shot_list, number_grover_list):\n",
+    "    \"\"\"\n",
+    "        calculate the total number of oracle calls\n",
+    "            M: upper limit of the sum in Fisher information \n",
+    "            shots_list:  list of number of shots\n",
+    "            numebr_grover_list: list of number of Grover operators        \n",
+    "\n",
+    "        Return:\n",
+    "            Norac: the total number of oracle calls\n",
+    "    \"\"\"\n",
+    "    Norac = 0\n",
+    "    for k in range(M + 1):\n",
+    "        Nk = shots_list[k]\n",
+    "        mk = number_grover_list[k]\n",
+    "        Norac += Nk * (2 * mk + 1)\n",
+    "    return Norac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we can run the algorithm as below: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qc_list = create_grover_circuit(number_grover_list, nbit,\n",
+    "                                b_max)  # list of Grover circuits\n",
+    "hit_list = run_grover(qc_list, number_grover_list, shots_list,\n",
+    "                      backend)  # list of number of grover operators\n",
+    "thetaCandidate_list = calculate_theta(\n",
+    "    hit_list, number_grover_list, shots_list)  # list of estimated theta values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now plot to find the correlation between the number of oracle calls and the approximation error of $\\theta_a$, as well as the lower bound of such error provided by the Cramér-Rao. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEOCAYAAACetPCkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvNQv5yAAAIABJREFUeJzt3XucTfX+x/HXZ8ZgyKVQIUWUcsu1iISE5K6SOl1dQvcORb9u53Q6KXUqIZHSOZykYkopl5ASuUSIJikdly6omaihMX1/f6xtGmNm7D0ze9bee97Px2M/2nvttdd6z1jNZ6/1/a7v15xziIiIBCvO7wAiIhJdVDhERCQkKhwiIhISFQ4REQmJCoeIiIREhUNEREKiwiEiIiFR4RARkZCocIiISEhUOEREJCQl/A4QDpUrV3Y1a9b0O4aISFRZs2bNHudclWOtF1OFw8y6A93r1KnD6tWr/Y4jIhJVzOzbYNaLqUtVzrk5zrnBFSpU8DuKiEjMiqnCISIi4afCISIiIYmpNg4RKXzp6ens2LGDAwcO+B1FCknp0qU55ZRTSEhIyNfnVThEJE87duygXLly1KxZEzPzO44UkHOOvXv3smPHDmrVqpWvbehSlYjk6cCBA1SqVElFI0aYGZUqVSrQGaQKR1bbV8IPm/xOIRJxVDRiS0H/PVU4spp3L0xsA3NHwG8/+Z1GRALi4+Np3Lhx5mP06NG5rpuUlMSmTX9+AXzggQdYuHBhgTOkpKQwYcKEkD/30EMP8cQTTxyxbMmSJbRq1eqIZYcOHeKkk07iu+++C2lbflAbR1ZXzYRF/4BVL8CG16HD/0GzGyAu3u9kIlEjae1OxsxLZldKGtUqJjKic116NaleoG0mJiaybt264PaflES3bt2oV68eAH//+98LtO/DDheOYcOGFXhbbdu2ZceOHWzbto3Do1wsXLiQBg0aULVq1QJvP9x0xpFVmROg27/gpqVwYj1456/w/IWwbZnfyUSiQtLanYyatYGdKWk4YGdKGqNmbSBp7c6w7G/kyJHUq1ePRo0aMXz4cD7++GPeeustRowYQePGjdm6dSvXX389r7/+OgA1a9bk3nvvpVWrVjRv3pxPP/2Uzp07U7t2bSZOnAjA/v37ueiii2jatCkNGzbkzTffzNzX1q1bady4MSNGjABgzJgxtGjRgkaNGvHggw9m5nrkkUeoW7cuHTt2JDk5+ajccXFxXH755bz66quZy2bMmEH//v0BmDx5Mi1atOCcc86hb9++/Pbbb0dto127dpkjZOzZsyezAGVkZDBixIjMXM8//3xBf81H0RlHwFHfkjo9T68WK2H+/TC1K9TvDRc/DBVr+B1VJGKNmZdMWnrGEcvS0jMYMy+5QGcdaWlpNG7cOPP1qFGjuPjii5k9ezZffPEFZkZKSgoVK1akR48edOvWjcsuuyzHbdWoUYPly5dz5513cv3117Ns2TIOHDhA/fr1GTJkCKVLl2b27NmUL1+ePXv20LJlS3r06MHo0aPZuHFj5pnP/Pnz2bJlCytXrsQ5R48ePVi6dClly5ZlxowZrF27lkOHDtG0aVOaNWt2VI7+/fszePBg7rnnHg4ePMjcuXN56qmnAOjTpw+DBg0C4L777mPKlCnceuutQf2upkyZQoUKFVi1ahUHDx6kdevWdOrUKd89qHISU4Uj61hVoTj8LenwAb8zJY1RszdCn/PodcsqWPYMLHsakt+DNndA69shITEMP4FIdNuVkhbS8mDldKnq0KFDlC5dmoEDB3LppZfSrVu3oLbVo0cPABo2bMj+/fspV64c5cqVo3Tp0qSkpFC2bFnuvfdeli5dSlxcHDt37uSHH344ajvz589n/vz5NGnSBPDOVLZs2cK+ffvo3bs3ZcqUOWJ/2bVo0YL9+/eTnJzM5s2badmyJccffzwAGzdu5L777iMlJYX9+/fTuXPn4H5RgVzr16/PPMtKTU1ly5YthVo4YupSVX7HqsrrWxIly0D7UXDLKjizMyx5FMa1gM+TwLnCjC8S9apVzPkLVW7LC6JEiRKsXLmSvn37kpSURJcuXYL6XKlSpQDvctHh54dfHzp0iOnTp7N7927WrFnDunXrOOmkk3LsuuqcY9SoUaxbt45169bx1VdfMWDAACD4XktXXnklM2bMOOIyFcD111/PuHHj2LBhAw8++GCO+y9RogR//PEHwBHvO+d49tlnM3N98803dOrUKag8wYqpwpFfQX1LqngqXPEyXPc2lK4Ar10HL3eHHz4vopQikW9E57okJhzZmSQxIZ4RnesW+r72799PamoqXbt25emnn848IylXrhz79u3L93ZTU1M58cQTSUhIYPHixXz77bc5brdz5868+OKL7N+/H4CdO3fy448/0rZtW2bPnk1aWhr79u1jzpw5ue6rf//+TJs2jUWLFh1xZrJv3z6qVq1Keno606dPz/GzNWvWZM2aNQCZZxeHcz333HOkp6cD8OWXX/Lrr7/m87eRs5i6VJVf1SomsjOH4pHjt6RaF8DgD+DTqV4PrIltoPmN0P7/vMZ1kWLscDtGYfeqyt7G0aVLF26//XZ69uzJgQMHcM5ltg9ceeWVDBo0iLFjxx7xBzVYV199Nd27d6d58+Y0btyYs846C4BKlSrRunVrGjRowCWXXMKYMWPYvHlzZrfa4447jmnTptG0aVP69etH48aNOe2007jgggty3Ve9evUoU6YMzZo1o2zZspnLH374Yc477zxOO+00GjZsmGMhHD58OFdccQX/+c9/6NChQ+bygQMHsm3bNpo2bYpzjipVqpCUlBTy7yEv5mLwckvz5s1dKPNxZG/jAO9b0qN9GuZ9wP/2Eyz+J6ye4p2FtA90341XPZbYsXnzZs4++2y/Y0ghy+nf1czWOOeaH+uzulSF9y3p0T4NqV4xEQOqV0w8dtEA7wzj0idgyEdwUgOYOxyebwvffFgkuUVE/KCvxgG9mlTP/+n0SfXhujmw+S2Ydx+83A3q9YRO//DaRkREYojOOAqLmVcsblkJ7e6FL+d7va8W/xN+P/rmHRGRaKXCUdgSEqHdPV733bpd4YPHvAKycZa674pITFDhCJeKNeDyl+D6uZB4PLx+A0ztBt9v8DuZiEiBqHCEW83WcNMHcOm/4MdNXuP523fCr3v9TiYiuZg+fTr/+9///I4RsVQ4ikJcPLQYALeugRaDYM3L8GxT+GQSZBzyO51IxPv++++58sorqV27NvXq1aNr1658+eWXYdnXlClT2L17N6eeGlzHlqlTp1KlSpXMez4O308Sy1Q4ilKZE6Dr41733arnwLsj4PkL4OsP/E4mErGcc/Tu3Zt27dqxdetWNm3axD//+c8jxo/KyMjIYwuhGTBgAHfccUeO7+W2n379+rFu3TqWLVvGI488wvbt2wstTyRS4fDDSfXg2jeh3zT4fT/8uwe8+hf4+Vu/k4lEnMWLF5OQkMCQIUMylzVu3JiMjAzat2/PVVddRcOGDQHo1asXzZo1o379+kyaNClz/eOOO4577rmHZs2a0bFjR1auXEm7du04/fTTeeutt4DchyNfsmTJUfvJTaVKlahTp07mZExz5szhvPPOo0mTJnTs2DGz2P3000/06tWLRo0a0bJlS9avX194v7AioPs4/GIGZ3eHOh3h43Hw0b+8Lrytb/dG4C1Z9tjbEClq744s/A4eJzeES3Kf0W/jxo05DksOsHLlSjZu3Jg58uuLL77ICSecQFpaGi1atKBv375UqlSJX3/9lXbt2vHYY4/Ru3dv7rvvPhYsWMCmTZu47rrr6NGjR67Dkee0n9z873//48CBAzRq1AiANm3asGLFCsyMF154gccff5wnn3ySBx98kCZNmpCUlMSiRYu49tprg56oKhKocPgtIREuHAGNr4IFD8DSx2HddLj479Cgr1dgRCRH55577hF/zMeOHcvs2bMB2L59O1u2bKFSpUqULFkyc/Tchg0bUqpUKRISEmjYsCHbtm0Dch+OvGTJkkftJ7tXX32VxYsXk5yczOTJkyldujQAO3bsoF+/fnz33Xf8/vvvmdv46KOPeOONNwDo0KEDe/fuJTU1lVBH9vaLCkekqFAdLpviNaK/eze8MQBWTfG+iVU9x+90Ip48zgzCpX79+rkOVph1YMAlS5awcOFCli9fTpkyZWjXrl3mcOMJCQmZQ51nHU798FDq8Odw5NnnvliyZMkR+xk/fjyTJ08GYO7cuYDXxjFu3DiWL1/OpZdeyiWXXMLJJ5/Mrbfeyl133UWPHj1YsmQJDz30UOa+sgt2KPZIoDaOSHPa+d7ou92ehj3J3tS1c+5Q910ptjp06MDBgwcz/1gDrFq1ig8+OLJTSWpqKscffzxlypThiy++YMWKFSHtJ9jhyG+++ebMuS6qVat2xHutWrXimmuu4ZlnnsnMVL26N5TRyy+/nLle27ZtM4dLX7JkCZUrV6Z8+fIh5fVTTBUOM+tuZpNSU1P9jlIwcfHQ/Aav++55Q+DTf8OzTWDFRMhI9zudSJEyM2bPns2CBQuoXbs29evX56GHHjrqj3aXLl04dOgQjRo14v7776dly5Yh7WfgwIHUq1ePpk2b0qBBA2666abMs5FQ3HPPPbz00kvs27ePhx56iMsvv5wLLriAypUrZ67z0EMPsXr1aho1asTIkSOPKCrRQMOqR4Mfv4D37oGvl0CVs6DLaKjd3u9UUkxoWPXYpGHVY92JZ8E1SdBvOqSnwX96wYyr4adv/E4mIsWQCke0MIOzu8HNK6HD/bB1EYw/D95/GA7u9zudiBQjKhzRJqE0tB3utX/U6wkfPuGNvrv+NY2+KyJFQoUjWpWvBn0nw43z4LgqMGsgvNgFdkXPTUQSPWKxLbQ4K+i/pwpHtDu1JQxaDN3Hwt6vYFI7eOtW2L/b72SAN59769GLqDXyHVqPXkTS2p1+R5IQlS5dmr1796p4xAjnHHv37s28STE/1KsqlqSlwAePw8rnIaEstBsJ5w6C+ARf4iSt3cmoWRtIS/9zYLjEhPjg5nOXiJGens6OHTsyb6aT6Fe6dGlOOeUUEhKO/NsQbK8qFY5YtDsZ3hvpNaBXrgtdHoU6FxV5jNajF7EzJe2o5dUrJrJsZIcizyMieVN33OKsSl34yyy48hXI+B2m9YFX+sNPXxdpjF05FI28lotIdFDhiFVmcFZXuPkTuOhBb86P8efBwr8VWffdahUTQ1ouItFBhSPWlSgFF9zldd+t39sbvn1cc/js1bB33x3RuS6JCfFHLEtMiGdE57ph3a+IhJcKR3FRvir0mQQDFkC5k2H2YJjSCXZ+GrZd9mpSnUf7NKR6xUQMr21DDeMi0U+N48XRH394c368/zf4dQ80+Yt3Oeu4Kn4nExEfqXFcchcXB02v8S5ftboZPnsFnm3qzUR46He/04lIhFPhKM5KV4DOj8DQ5VDjXJj/f/Dc+bBlod/JRCSCqXAIVDkTrn4d+r8KLgOm94X/Xgl7t/qdTEQikAqHeMygbhcYtgI6/g22fQgTWsKCB+HgPr/TiUgEUeGQI5UoBW3u8No/GvSFZU/Ds81h3Steo7qIFHsqHJKzcidD74kw8H1vJN6kIfBiJ9i5xu9kIuIzFQ7J2ynNveLRcwL8/C1M7gBJN8O+H/xOJiI+UeGQY4uLgyZXe5evzr8N1r8KzzaDZWPVfVekGFLhkOCVLg+dHvYa0E9rBQvuh+dawZfz/U4mIkVIhUNCV7kOXP0aXBWYrva/l8P0K9R9V6SYUOGQ/Duzk3f2cfHD8O3H3ui78++HA7/4nUxEwkiFQwqmRElofZvX/tHoCvh4rDf67trp6r4rEqMivnCYWS8zm2xmb5pZJ7/zSC7KnQS9JsDARVChBrw5DKZ0hB0abFIk1oS1cJjZi2b2o5ltzLa8i5klm9lXZjYyr20455Kcc4OA64F+YYwrheGUZt7Q7b0mQuoOeOEimD0U9n3vdzIRKSThPuOYCnTJusDM4oHxwCVAPaC/mdUzs4Zm9na2x4lZPnpf4HMS6eLioHF/7/JV69thw2te990lo4ts9kERCZ+wFg7n3FLgp2yLzwW+cs597Zz7HZgB9HTObXDOdcv2+NE8jwHvOufCN+uQFL5S5eDiv3vT19ZuD0sehbFNYNULkJHudzoRySc/2jiqA9uzvN4RWJabW4GOwGVmNiS3lcxssJmtNrPVu3fvLpykUjgq1YZ+07xLWJVqwzt/9QZQ3PRm2KevFZHC50fhsByW5frXwzk31jnXzDk3xDk3MY/1JjnnmjvnmlepopnsIlKNc+GGd6H/DIgrATOvhRc6wrZlficTkRD4UTh2ADWyvD4F2OVDDvGDGdS9BIYsgx7Pwi87YWpX+G8/+GGT3+lEJAh+FI5VwBlmVsvMSgJXAm/5kEP8FF8Cml4Lt37qzXf+7ccwsbU3gGLqTr/TiUgewt0d9xVgOVDXzHaY2QDn3CHgFmAesBmY6Zz7PJw5JIKVLAMX3AW3fwbnDYUNM735zxc8CGkpfqcTkRyYi6HGSTPrDnSvU6fOoC1btvgdR/Lj529h8SOwfqY3J3rb4dBiECSU9jsZSWt3MmZeMrtS0qhWMZERnevSq0le/TpEoouZrXHONT/merFUOA5r3ry5W71adyxHte/Ww8KHYOv73p3oHe6Dhld494j4IGntTkbN2kBaekbmssSEeB7t01DFQ2JGsIUj4occkWKqaiO4ZhZc+yaUOQFm3wTPt4UtC33pwjtmXvIRRQMgLT2DMfOSizyLiN/yLBxmFm9mC4sqjMhRTm8Hg5ZA3ylw8BeY3hf+3QN2rS3SGLtS0kJaLhLL8iwczrkM4Dczq1BEeUSOFhcHDS+DW1ZBl8fgh89hUjt4/Ub46esiiVCtYmJIy0ViWTCXqg4AG8xsipmNPfwId7D8MLPuZjYpNTXV7ygSDiVKQcshcNs6uGA4fDEXxp0Lc++GX/eEddcjOtclMSH+iGWJCfGM6Fw3rPsViUTHbBw3s+tyWu6cezksiQqBGseLiV++gw9Gw6f/gYQy3rwgrW6GkmXDsjv1qpJYV6i9qgI36p0ZeJnsnIvoEepUOIqZ3V/C+3+DL96G406CdiOhyTUQn+B3MpGoUmi9qsysHbAFb0jzCcCXZta2wAlFCkuVM+HK6XDjfDi+Frx9Z2AQxbc0iKJIGATTxvEk0Mk5d6Fzri3QGXgqvLFE8uHU8+DG9+DK/4LFwcxrYEon+Ha538lEYkowhSPBOZfZWd059yWgawASmczgrEth6HLoPhZSt8NLXeCV/vDjF36nE4kJwRSO1YEeVe0Cj8nAmnAHyw/1qpJM8SWg2XXeIIod7odtH8FzreDNW+AXDcYsUhDB9KoqBdwMtMGbS2MpMME5dzD88fJHjeNylF/3wodPwMrJ3lwgLYd609omVvQ7mUjEKJReVYH5wV92zv2lMMOFmwqH5OrnbbDoH9486InHQ9sR0GKgd4+ISDFXKL2qAneOVwl0xxWJfsfXhL4vwE1LoWpjmHcvjGvujcb7xx9+pxOJCsG0cWwDlpnZ/WZ21+FHmHOJhFfVc+DaJLhmNpSuCLMGwaS28NX7ficTiXjBFI5dwNuBdctleYhEv9odYPAH0OcFOJAK0/rAv3vCrnV+JxOJWCXyejPQxnGcc25EEeUpkCwTOfkdRaJJXBw0uhzq9YBVU2DpGJh0ITS4DC6637u8JSKZgulV9b5z7qIiylMo1DguBXIgFZY9A8snwB+HvMbztsOhbGW/k4mEVaGNVWVmTwJnAK8Bvx5e7pybVdCQ4aLCIYXil12w5FFYOw0SykKb26HlsLANoijit8KcAfAEYC/QAegeeHQrWDyRKFC+GvR4FoatgFptvW68Y5vC2unqgSXFmuYcFwnWt8thwf2wYxXUaAmXPgknN/A7lUihKfAZh5nNzPL8sWzvzS9YPJEodForbwTeHuNgz5feHOjv3QsHfvE7mUiRyutS1RlZnl+c7b0qYcgiEvni4qDpNXDrGu+/KybAuBaw4XUN4S7FRl6FI6//C/R/iBRvZU6A7s/AwPeh3EnwxgDv/o89W/xOJhJ2eRWOMmbWxMyaAYmB500Pvy6ifCHR6LhS5E5pBoMWQ9cnvJsGJ7SChX+D33/zO5lI2OTaOG5mi/P6oHOufVgSFQI1josv9v8ICx6Az16BCqfCJaOhbldvjhCRKFCoc45HGxUO8dW2ZfDOX2H3ZjijM1zyGJxQy+9UIsdUmPdxiEgoaraGIR9Cp3/At8u8+c8/eBzSD/idTKRQqHCIhEN8Apx/K9y8Es7sAosf8WYg/Gqh38lECkyFQyScKlSHK16Gv8wCDKb1hZnXQupOv5OJ5FtQhcPMqpvZ+WbW9vAj3MFEYkqdi2DYcmh/H3w5z7v3Y9kzkJHudzKRkOU5rDpk3jXeD9gEZAQWO7y5x0UkWCVKwYUjvCHc3x3p9cBa919v6JKabfxOJxK0YxYOoBdQ1zl3MNxhRIqF42vCVTMg+V14926Yeik06gcXP+zdTCgS4YK5VPU1kBDuICLFTt1LYNgn0HYEfD7bm/v8k+ch45DfyUTyFMx8HG8A5wDvA5lnHc6528IbLXRZZgActGWLhn6QKLLnK5g7HL5eDCc3hEufghot/E4lxUxhTuR0XU7LnXMv5zNb2OkGQIlKzsGmJHhvFOz7DppeCx3/5o2LJVIEgi0cx2zjcM69bGYlgTMDi5Kdc+oKIlLYzKB+b6jTEZaMhhXPweY5XvFoco03Mq9IBDjmkWhm7YAtwHhgAvCluuOKhFGpctD5Ee/u8ypnw5zb4MVO8N1nficTAYJrHH8S6OScu9A51xboDDwV3lgiwkn14Ya50Gsi/LwNJrWDuXfDAY3+LP4KpnAkOOeSD79wzn2JelmJFA0zaNwfblkNzQfAyknwbHP47FVNHCW+CaZwrDazKWbWLvCYDKwJdzARySKxIlz6BAxeDBVrwOzBMLUb/LjZ72RSDAVTOIYCnwO3Abfj3UE+JJyhRCQX1ZrAgIXQ7Wn4YSNMbAPz74eD+/1OJsWI5uMQiVa/7oGFD8LaaVC+OnR5FM7uoYmjJN8KPB+Hmc0M/HeDma3P/ijMsCKSD2UrQ8/xcON8SDzBG3V3Wl/Yu9XvZBLj8po6tqpz7jszOy2n951z34Y1WQHojEOKnYxDsOoFWPQPyDgIre+AC+6ChES/k0kUKfAZh3Puu8DTYc65b7M+gGGFFVRECkF8CWg5BG5dDfV6wtLHYfx5sGWB38kkBgXTOH5xDssuKewgIlIIyp0MfV+A6+Z4w7hPvwxmD4W0n/1OJjEkrzaOoWa2AaibrX3jGyAi2zjMrLuZTUpN1Q1SUszVagtDPoILhsP6V2F8S/hirt+pJEbk1cZRATgeeBQYmeWtfc65n4ogW76pjUMki13r4M2bve67DS+HSx7XwImSo8Jo40h1zm1zzvUPtGuk4c38d5yZnVqIWUUknKo1hkGLod0ob96P8efC50l+p5IoFswgh93NbAvwDfABsA14N8y5RKQwlSgJ7UbC4A+gfDV47Tqv++7+3X4nkygUTOP4P4CWwJfOuVrARcCysKYSkfA4uQEMXAQXPeBNXTv+XNjwusa9kpAEUzjSnXN7gTgzi3POLQYahzmXiIRLfAm44K9w04dwwunwxgCYcTXs+97vZBIlgikcKWZ2HLAUmG5mzwCaFFkk2p14FgyYDxc/DFvf984+1v1XZx9yTMEUjp54DeN3Au8BW4Hu4QwlIkUkLh5a3wZDlnmTRiUNhf9eAak7/U4mEeyYhcM596tzLgMoA8wBpuH1rhKRWFG5DtzwLnR5DLZ9BBNawpqXdfYhOQqmV9VNZvYD3k1/q/Hm4tBNEiKxJi7OG7Zk6DKoeo43Ze1/ekPK//xOJhEmmEtVw4H6zrmazrnTnXO1nHOnhzuYiPjkhNPh2rfg0idhxyqY0MobQPGPP/xOJhEimMKxFfgt3EFEJILExUGLgTBsOZzSAt75K/y7B/z0jd/JJAIEUzhGAR+b2fNmNvbwI9zBRCQCVDwVrpkN3cfCd5/Bc+fDiud09lHMBVM4ngcWASvw2jcOP0SkODCDZtfBsBVQsw28NxJeugT2fOV3MvFJiSDWOeScuyvsSUQkslWoDlfNhM9mwHv3wMTW0P7/oNXNXrdeKTaCOeNYbGaDzayqmZ1w+BH2ZCISecygcX+4eSXUvggW3A9TLoYfv/A7mRShXIdVz1zBm38jOxfJPas0rLpIEXAONr4Bc0fA7/vhwnu8KWvjg7mQIZEo2GHVj1k4oomZdQe616lTZ9CWLVv8jiNSPOzfDXOHw6Yk7/6PnhO8wRQl6hS4cJhZB+fcIjPrk9P7zrlZBcwYNjrjEPHBpje9brtpKdB2OLS5yxvOXaJGsIUjr3PKC/F6U+U0LpUDIrZwiIgP6vWE09p4DedLHoXNc6DneG8iKYkpwbRx1HLOfXOsZZFEZxwiPvtiLrx9J/y6G9rcCRfeDSVK+Z1KjqHAU8dm8UYOy14PPZKIFBtndYWbV0CjfvDhE/D8hbBDt3/FilwvVZnZWUB9oEK2do7yQOlwBxORKJd4PPR+Dhr0gTm3w5SO0OoWaH8vJCT6nU4KIK82jrpAN6AiR7Zz7AMGhTOUiMSQMy72xryafz98PBaS53o9r049z+9kkk/BtHG0cs4tL6I8hUJtHCIRautieOs2SN0OLYdCh/ugZFm/U0lAYbZx9Daz8maWYGbvm9keM/tLIWQUkeKmdnsY9rE38u6KCfBca2/iKIkqwRSOTs65X/AuW+0AzgRGhDWViBRI0tqdtB69iFoj36H16EUkrY2gqWBLlYNLn4Dr3/FeT70U3rsX0tP8zSVBC6ZwJAT+2xV4xTn3UxjziEgBJa3dyahZG9iZkoYDdqakMWrWhsgqHuCNtDt0GZw7GFaM93pe7VrrdyoJQjCFY46ZfQE0B943syrAgfDGEpH8GjMvmbT0jCOWpaVnMGZesk+J8lCyLHQdA3+ZBQf3wQsd4YPHIeOQ38kkD8csHM65kUAroLlzLh1vNsCe4Q4mIvmzKyXnSz65LffLEZfTXjfeafMG1O8Nix+BFztpvo/PLCyAAAAP4UlEQVQIlmvhMLO7s7zs6JzLAHDO/QrcFu5gIpI/1SrmfI9Ebsv9kNPltOFv/4+k0/8Gl70EP30NE9vAysmabTAC5XXGcWWW56OyvdclDFlEpBCM6FyXxIQjJ1ZKTIhnROe6PiU6Wp6X0xr0gaHLvTaQucNhWh9IjbD2mWIur8JhuTzP6bWIRIheTarzaJ+GVK+YiAHVKybyaJ+G9GpS3e9omY55Oa18Vbj6Nej2FGz/BJ5rBetf8+YAEd/ldee4y+V5Tq9FJIL0alI9ogpFdtUqJrIzh+JxxOU0M2h+I9S6EGYPgVkDIfkduPRfUEaTkPoprzOOc8zsFzPbBzQKPD/8umER5RORGBTS5bRKteGGd+GiB2Dz2zChJWxZUERJJSe5Fg7nXLxzrrxzrpxzrkTg+eHXCbl9TkTkWEK+nBZfAi74KwxaBGUqwfTLYM4dcHB/keYWT0xNHXuYxqoSiWHpB2DxP+DjcXB8Tej9vAZMLCSFOVaViEjkSCgNnf7hDVniMuClLrDwb3Dod7+TFRsqHCISnWq2hqEfQ+Or4aN/weQO8MPnfqcqFlQ4RCR6lSoHPcdB/xmw/3uY1A6WPQN/ZBzzo5J/KhwiEv3qXgLDVsAZnWDBAzC1G/y8ze9UMUuFQ0RiQ9nK0G8a9JoIP2z05vr49N+6aTAMVDhEJHaYQeP+XttHtSbw1q3wSn/Y/6PfyWKKCoeIxJ6KNeDat6Dzo7B1kXfT4Ka3/E4VMyK+cJjZ2WY20cxeN7OhfucRkSgRFwethsFNS6FCDZh5jTd0yYFUv5NFvbAWDjN70cx+NLON2ZZ3MbNkM/vKzEbmtQ3n3Gbn3BDgCrzJpEREgnfiWTBwIVx4D6yfCRPOh68/8DtVVAv3GcdUsg3BbmbxwHjgEqAe0N/M6plZQzN7O9vjxMBnegAfAe+HOa+IxKL4BGh/LwxY4N1A+O8e8O5IzXOeT2EtHM65pUD2OcrPBb5yzn3tnPsdmAH0dM5tcM51y/b4MbCdt5xz5wNXhzOviMS4U5rBTR9685x/8pzmOc8nP9o4qgPbs7zeEViWIzNrZ2Zjzex5YG4e6w02s9Vmtnr37t2Fl1ZEYkvJMt4859fM/nOe8yWPQUa638mihh+FI6dJoHLtaO2cW+Kcu805d5Nzbnwe601yzjV3zjWvUqVKoQQVkRhWuwMM+xjq94El/4QpnWDPFr9TRQU/CscOoEaW16cAu3zIISLFXeLx0HcyXD4Vfv4GJl4An0zSPOfH4EfhWAWcYWa1zKwk3tzm6mAtIv6p39sbsqRmG3h3BEzrrXnO8xDu7rivAMuBuma2w8wGOOcOAbcA84DNwEznXKEMaWlm3c1sUmqq+mmLSIjKnRyY5/xp2L4KJrTyuu9qyJKjaCInEZHsfvrau1lw+ydQr6dXTIrBPOeayElEJL9OOD0wz/mD8MVczXOejQqHiEhO4uLhgrtg8OI/5zl/Zzj8/pvfyXynwiEikpeTG8KgxdDqFlg1GSZdCLvW+Z3KVzFVONQ4LiJhkVAaOj8C174JB/fDCxfBh08W25kGY6pwOOfmOOcGV6hQwe8oIhKLTm8HQ5fB2d3h/b/D1Evh52/9TlXkYqpwiIiEXZkT4LKXoPck+OFzb6bBda8Uq267KhwiIqEyg3P6eWcfVRtB0hB47Xr4LfuYrrFJhUNEJL8qngrXzYGOD8EX78Bz53szDsY4FQ4RkYKIi4c2d3qTRZUqD//pDe+NgvQDficLm5gqHOpVJSK+qdYYbvoAzr0JVkyASe3g+w1+pwqLmCoc6lUlIr5KSISuj8PVb0DaTzC5AywbG3Oj7cZU4RARiQhndIShy+GMTrDgfm+q2tQdfqcqNCocIiJ5SFq7k9ajF1Fr5Du0Hr2IpLVBDrdethL0mwY9x3vT0044Hza8Ht6wRUSFQ0QkF0lrdzJq1gZ2pqThgJ0paYyatSH44mEGTf4CQz6EKnXhjQHw+gBISwlr7nBT4RARycWYecmkpR85rEhaegZj5iWHtqHDo+22/z/4fLZ30+A3HxZi0qKlwiEikotdKWkhLc9TfAm48G4YsABKlIKXu8P8++HQwQKmLHoxVTjUHVdEClO1iokhLQ/KKc28S1fNb4CPx8Lki+CHTfnfng9iqnCoO66IFKYRneuSmBB/xLLEhHhGdK5bsA2XLAvdnoL+r8K+77x7PpZPiJpuuzFVOEREClOvJtV5tE9DqldMxIDqFRN5tE9DejWpXjg7qNsFhi2H2u1h3iiY1ht+2VU42w4jzTkuIuI352DNVJh3L8SXhO7PQP1eRR5Dc46LiEQLM6/N46YPvR5Yr10Hs4fAgV/8TpYjFQ4RkUhRuQ4MmA8X3gPrX4WJreHb5X6nOooKh4hIJIlPgPb3wo3zwOJgaldvtsFDv/udLJMKh4hIJKpxLgz5CBpf7c1vPqUj7P7S71RAjBUO3cchIjGlVDnoOc4b8yplOzzfFlZO9n2a2pgqHLqPQ0Ri0tndvW67NVvD3OEw/XLY94NvcWKqcIiIxKxyJ8PVr0PXJ2Dbh/BcK9j8ti9RVDhERKKFGZw7CG5aCuWrw6tXw5u3wMH9RRpDhUNEJNpUqQsD34c2d8HaaTCxDWxfVWS7V+EQEYlGJUpCxwfhhrnwRwa82BkWPwoZ6WHftQqHiEg0O+18GPoRNLwclo6BH8M/0q4Kh4hItCtdAfo8D0M/hqrnhH13KhwiIrHixLOKZDcqHCIiEpKYKhy6c1xEJPxiqnDoznERkfAr4XcAEREpmKS1OxkzL5ldKWlUq5jIiM51C2+WwhyocIiIRLGktTsZNWsDaekZAOxMSWPUrA0AYSseMXWpSkSkuBkzLzmzaByWlp7BmHnJYdunCoeISBTblZIW0vLCoMIhIhLFqlVMDGl5YVDhEBGJYiM61yUxIf6IZYkJ8YzoXDds+1TjuIhIFDvcAK5eVSIiErReTaqHtVBkp0tVIiISEhUOEREJSUwVDo1VJSISfjFVODRWlYhI+MVU4RARkfAz55zfGQqdme0GUoDcrllVyOO9ysCecOQKg7x+jkjbR363E+rngln/WOvk930dO+HbT1EcP4Vx7BxrnUj/23Oac67KMddyzsXkA5iUz/dW+529MH7GSNtHfrcT6ueCWf9Y6+T3fR070X38FMaxc6x1YuVvTyxfqpqTz/eiSVH8HIW1j/xuJ9TPBbP+sdYp6PvRoKh+hmg6fgrj2DnWOrFw7MTmpaqCMLPVzrnmfueQ6KNjRwoimo6fWD7jyK9JfgeQqKVjRwoiao4fnXGIiEhIdMYhIiIhUeEQEZGQqHCIiEhIVDiOwcx6mdlkM3vTzDr5nUeih5mdbWYTzex1Mxvqdx6JLmZW1szWmFk3v7NkVywLh5m9aGY/mtnGbMu7mFmymX1lZiMBnHNJzrlBwPVAPx/iSgQJ8djZ7JwbAlwBREU3SwmfUI6dgHuAmUWbMjjFsnAAU4EuWReYWTwwHrgEqAf0N7N6WVa5L/C+FG9TCeHYMbMewEfA+0UbUyLQVII8dsysI7AJ+KGoQwajWBYO59xS4Kdsi88FvnLOfe2c+x2YAfQ0z2PAu865T4s6q0SWUI6dwPpvOefOB64u2qQSaUI8dtoDLYGrgEFmFlF/qzV17J+qA9uzvN4BnAfcCnQEKphZHefcRD/CSUTL8dgxs3ZAH6AUMNeHXBL5cjx2nHO3AJjZ9cAe59wfPmTLlQrHnyyHZc45NxYYW9RhJKrkduwsAZYUbRSJMjkeO5lPnJtadFGCF1GnPz7bAdTI8voUYJdPWSS66NiR/IrKY0eF40+rgDPMrJaZlQSuBN7yOZNEBx07kl9ReewUy8JhZq8Ay4G6ZrbDzAY45w4BtwDzgM3ATOfc537mlMijY0fyK5aOHQ1yKCIiISmWZxwiIpJ/KhwiIhISFQ4REQmJCoeIiIREhUNEREKiwiEiIiFR4ZCIY2bOzJ7M8nq4mT1USNueamaXFca2jrGfy81ss5ktDve+Avu73szGhXH7mb83M1tiZhomvhhT4ZBIdBDoY2aV/Q6SVWAI7GANAIY559qHeT8iRU6FQyLRIWAScGf2N7KfMZjZ/sB/25nZB2Y208y+NLPRZna1ma00sw1mVjvLZjqa2YeB9boFPh9vZmPMbJWZrTezm7Jsd7GZ/RfYkEOe/oHtbwwMv4+ZPQC0ASaa2Zhs61tgPxsDn+uX237MLCkwA9znZjY4yza6mNmnZvaZmR01z4eZVTGzNwI/yyoza53DOvFm9kQgw3ozu/Vw9sBnNprZJDPLaRC+rNuYmuVnOerfS2KTRseVSDUeWG9mj4fwmXOAs/HmPPgaeME5d66Z3Y43PP4dgfVqAhcCtYHFZlYHuBZIdc61MLNSwDIzmx9Y/1yggXPum6w7M7NqwGNAM+BnYL6Z9XLO/d3MOgDDnXOrs2XsAzQOZK0MrDKzpbns50bn3E9mlhhY7w28L3uTgbbOuW/M7IQcfg/PAE855z4ys1PxhrM4O9s6g4FaQBPn3KEs2xnnnPt74Of7D9ANmJPDPgj8HNWdcw0C61fMZT2JMSocEpGcc7+Y2b+B24C0ID+2yjn3HYCZbQUO/+HfgDcxzmEzA/MbbDGzr4GzgE5AoyxnMxWAM4DfgZXZi0ZAC2CJc253YJ/TgbZAUh4Z2wCvOOcygB/M7IPAdn7JYT+3mVnvwPMagTxVgKWH13POZZ8YCLz5Y+plOVkob2blnHP7sq0zMTBWUtbttDezu4EywAnA5+ReOL4GTjezZ4F3+PP3LTFOhUMi2dPAp8BLWZYdInCJNXAZpWSW9w5mef5Hltd/cOSxnn2ANoc3L8Ktzrl5Wd8wbzKmX3PJl+tlnDzk9ZnM/QT22xFo5Zz7zcyWAKUDnz/WAHNxgc/lVXCP2o6ZlQYmAM2dc9sDHRJK57YB59zPZnYO0Bm4GW9u9RuPkU1igNo4JGIFvgXPxGtoPmwb3qUh8KbYTMjHpi83s7hAu8fpQDLe5ZyhZpYAYGZnmlnZY2znE+BCM6scaNDuD3xwjM8sBfoF2geq4J2hrMxhvQrAz4GicRbeNKLgja56oZnVCuTM6VLVfLwRVwms0ziXdYaYWYks2zlcJPaY2XFAnr3PAp0X4pxzbwD3A03zWl9ih844JNI9SZY/gnjX9980s5XA++R+NpCXZLw/8CcBQ5xzB8zsBby2j08DZzK7gV55bcQ5952ZjQIW432Dn+uce/MY+54NtAI+w/vGf7dz7vtAccjqPbw/7OsDeVcE9rk70FA+y7x5qH8ELs722duA8YHPlsArVkOyrfMCcCZeO1I6MNk5N87MJuNd2tuGN1dEXqoDL9mf82GPOsb6EiM0rLqIiIREl6pERCQkKhwiIhISFQ4REQmJCoeIiIREhUNEREKiwiEiIiFR4RARkZCocIiISEj+H4+C9v0jIoKuAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x22fdc5f61d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "error_list = np.abs(np.sin(thetaCandidate_list)**2 - discretizedResult)  # list of estimation errors\n",
+    "OracleCall_list = []  # list of number of oracle calls\n",
+    "ErrorCramérRao_list = []  # list of Cramér-Rao lower bound\n",
+    "for i in range(len(number_grover_list)):\n",
+    "    OracleCall_list.append(\n",
+    "        CalcNumberOracleCalls(i, shots_list, number_grover_list))\n",
+    "    ErrorCramérRao_list.append(\n",
+    "        CalcErrorCramérRao(i, shots_list, discretizedResult, number_grover_list))\n",
+    "\n",
+    "p1 = plt.plot(OracleCall_list, error_list, 'o')\n",
+    "p2 = plt.plot( OracleCall_list, ErrorCramérRao_list)\n",
+    "plt.xscale('log')\n",
+    "plt.xlabel(\"Number of oracle calls\")\n",
+    "plt.yscale('log')\n",
+    "plt.ylabel(\"Estimation Error\")\n",
+    "plt.legend((p1[0], p2[0]), (\"Estimated Value\", \"Cramér-Rao\"))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From the above graph, we can see that the estimation error tends to decrease with the increase of the number oracle calls but has deviates from Cramér-Rao lower bound. Because Cramér-Rao lower bound express a bound for statistical mean of estimation errors, we now repeat the above algorithm $n_{trial}=100$ times to estimate the statisitical mean of errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n_trial=(100/100)\r"
+     ]
+    }
+   ],
+   "source": [
+    "n_trial = 100\n",
+    "error_list= np.zeros_like(number_grover_list,dtype=float)\n",
+    "qc_list = create_grover_circuit(number_grover_list, nbit, b_max)\n",
+    "for i in range(n_trial):\n",
+    "    sys.stdout.write(\"n_trial=(%d/%d)\\r\" % ((i + 1), n_trial))\n",
+    "    sys.stdout.flush()\n",
+    "    hit_list = run_grover(qc_list, number_grover_list, shots_list, backend)\n",
+    "    thetaCandidate_list = calculate_theta(hit_list, number_grover_list, shots_list)\n",
+    "    error_list += (np.sin(thetaCandidate_list)**2 - discretizedResult)**2  # list of estimation errors\n",
+    "\n",
+    "error_list = (error_list / (n_trial-1))**(1/2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEOCAYAAACetPCkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvNQv5yAAAIABJREFUeJzt3Xd4VGXax/HvnRBIKAYpuoIoCgqCICUoiNJEQxexAFZUQLDt664s4KrLWnZVdHUREUERC4quQgDFBREii6J0BUXAggqoIJoIGPrz/nEmMcSUmSSTMzP5fa7rXMycOeVOOFfuebo55xAREQlWnN8BiIhIdFHiEBGRkChxiIhISJQ4REQkJEocIiISEiUOEREJiRKHiIiERIlDRERCosQhIiIhUeIQEZGQVPA7gHCoVauWq1+/vt9hiIhElZUrV/7onKtd1HExmTjq16/PihUr/A5DRCSqmNnXwRynqioREQlJTCUOM+ttZpMyMzP9DkVEJGbFVOJwzs1xzg1NTk72OxQRkZgVk20cIlJ6Dhw4wJYtW9i7d6/foUgpSUxM5PjjjychIaFY5ytxBKSt3srYeRvYlpFFnepJjEhtRN+Wdf0OS8R3W7ZsoVq1atSvXx8z8zscKSHnHDt37mTLli2cdNJJxbpGTFVVFVfa6q2MnrGWrRlZOGBrRhajZ6wlbfVWv0MT8d3evXupWbOmkkaMMDNq1qxZohKkEgcwdt4Gsg4cOmJf1oFDjJ23waeIRCKLkkZsKen/pxIHsC0jK6T9IlK24uPjadGiRc72wAMPFHhsWloan376ac77u+++mwULFpQ4hoyMDCZMmBDyeWPGjOHhhx8+Yl96ejrt2rU7Yt/Bgwc59thj+e6770K6lh/UxgHUqZ7E1nySRJ3qST5EIxLdwtFemJSUxJo1a4K7f1oavXr1okmTJgDcc889Jbp3tuzEceONN5b4Wh06dGDLli1s3ryZ7FkuFixYwOmnn85xxx1X4uuHm0ocwIjURiQlxJNin9HUNgOQlBDPiNRG/gYmEmXKur1w1KhRNGnShObNm3P77bfz/vvvM3v2bEaMGEGLFi344osvGDRoEK+99hrgzSpxxx130K5dO1JSUli1ahWpqak0aNCAiRMnArB7927OO+88WrVqRbNmzZg1a1bOvb744gtatGjBiBEjABg7dixt2rShefPm/O1vf8uJ6/7776dRo0Z07dqVDRt+X+UdFxfHpZdeyiuvvJKzb/r06QwcOBCAyZMn06ZNG8444wwuvvhifv31199do1OnTjkzZPz44485CejQoUOMGDEiJ66nnnqqpL/m31GJA3K+DTWYfTdNDm9kZoXuJKXeTU/1qhIJSWHthSUpdWRlZdGiRYuc96NHj+b8889n5syZfPbZZ5gZGRkZVK9enT59+tCrVy8uueSSfK9Vr149li5dym233cagQYN477332Lt3L02bNmXYsGEkJiYyc+ZMjjrqKH788Ufatm1Lnz59eOCBB1i3bl1OyWf+/Pls2rSJZcuW4ZyjT58+LF68mCpVqjB9+nRWr17NwYMHadWqFa1bt/5dHAMHDmTo0KGMHDmSffv2MXfuXB599FEA+vXrx5AhQwC48847eeaZZ7jllluC+l0988wzJCcns3z5cvbt20f79u254IILit2DKj9KHAF9W9aFxvNh0f1csvxpSF8GCffAGQMhTgUzkWCEq70wv6qqgwcPkpiYyODBg+nZsye9evUK6lp9+vQBoFmzZuzevZtq1apRrVo1EhMTycjIoEqVKtxxxx0sXryYuLg4tm7dyg8//PC768yfP5/58+fTsmVLwCupbNq0iV27dnHRRRdRuXLlI+6XV5s2bdi9ezcbNmxg/fr1tG3blqOPPhqAdevWceedd5KRkcHu3btJTU0N7hcViOvjjz/OKWVlZmayadMmJY6wSaoOPcZCy6vgzT/DrBth1XPQ42E4rrnf0YlEvLJsL6xQoQLLli3jnXfeYfr06YwfP56FCxcWeV6lSpUAr7oo+3X2+4MHDzJt2jR27NjBypUrSUhIoH79+vl2XXXOMXr0aG644YYj9j/22GNB91oaMGAA06dPZ/369TnVVACDBg0iLS2NM844g6lTp5Kenp7vz3/48GGAI+JzzvH444+HlGxCpa/S+TmuOVw3Dy6cADu/gEkdYe4IyMrwOzKRiJbdXphbuNoLd+/eTWZmJj169OCxxx7LKZFUq1aNXbt2Ffu6mZmZHHPMMSQkJLBo0SK+/vrrfK+bmprKlClT2L17NwBbt25l+/btdOjQgZkzZ5KVlcWuXbuYM2dOgfcaOHAgL774IgsXLjyiZLJr1y6OO+44Dhw4wLRp0/I9t379+qxcuRIgp3SRHdeTTz7JgQMHANi4cSN79uwp5m8jfzFV4jCz3kDvhg0blvxicXHQ8gpo3AMW3g/Ln4ZPZsL590DzAaq+EslHdjtGafeqytvG0a1bN/74xz9y4YUXsnfvXpxzOe0DAwYMYMiQIYwbN+6IP6jBuuKKK+jduzcpKSm0aNGCxo0bA1CzZk3at2/P6aefTvfu3Rk7dizr16/P6VZbtWpVXnzxRVq1akX//v1p0aIFJ554Iueee26B92rSpAmVK1emdevWVKlSJWf/vffey1lnncWJJ55Is2bN8k2Et99+O5dddhkvvPACXbp0ydk/ePBgNm/eTKtWrXDOUbt2bdLS0kL+PRTGnHOlesFIkJKS4kp9PY7vPoI3b4cty6DeWaq+knJj/fr1nHbaaX6HIaUsv/9XM1vpnEsp6lx9bQ7WcWcEqq+egJ2fB6qv/qLqKxEpd5Q4QhEXBy2vhFtWQsp1sHwyjE+BNS9DDJbcRETyo8RRHElHQ89HYMgiOLo+pA2DKd3g+7V+RyYiEnZKHCVRpwVcNx/6jIedm+CpDvDWSFVfiUhMU+Ioqbg4aHUV3LzCq7768ClVX4lITFPiKC2Va3jVV0MXQfUTveqrZ7vD9+v8jkxEQjRt2jS++eYbv8OIWEocpa1OS7j+bejzOPy48bfqq72ZfkcmErW+//57BgwYQIMGDWjSpAk9evRg48aNYbnXM888w44dOzjhhBOCOn7q1KnUrl07Z8xH9niSWBZTAwAjRlwctLoaGveChfd51VfrZsAF90Lz/qBFcUSC5pzjoosu4pprrmH69OkArFmzhh9++IFTTz0V8GaEjY+PL+wyQbv++usL/Kyg+/Tv35/x48ezc+dOGjVqxCWXXEK9evVKJZ5IpBJHOFWuAb3+Fai+OgFm3qDqK5EQLVq0iISEBIYNG5azr0WLFhw6dIjOnTtz+eWX06xZMwD69u1L69atadq0KZMmTco5vmrVqowcOZLWrVvTtWtXli1bRqdOnTj55JOZPXs2UPB05Onp6b+7T0Fq1qxJw4YNcxZjmjNnDmeddRYtW7aka9euOZMl/vTTT/Tt25fmzZvTtm1bPv7449L7hZUBlTjKQnb11ZoX4e2/edVXZw6FzqMhMdnv6ESC99ao0u92/odm0L3gFf3WrVuX77TkAMuWLWPdunU5M79OmTKFGjVqkJWVRZs2bbj44oupWbMme/bsoVOnTjz44INcdNFF3Hnnnbz99tt8+umnXHPNNfTp06fA6cjzu09BvvnmG/bu3Uvz5t6sEueccw4ffPABZsbTTz/NQw89xCOPPMLf/vY3WrZsSVpaGgsXLuTqq68OeqGqSKDEUVaOqL66Fz6cCOtehwvug+aXqfpKpBjOPPPMI/6Yjxs3jpkzZwLw7bffsmnTJmrWrEnFihXp1q0b4E2nXqlSJRISEmjWrBmbN28GCp6OvGLFir+7T16vvPIKixYtYsOGDUyePJnExEQAtmzZQv/+/fnuu+/Yv39/zjWWLFnC66+/DkCXLl3YuXMnmZmZJCdHxxdJJY6yVrkG9HrUm7p97u0wcyisnAo9H4Zjm/odnUjhCikZhEvTpk0LnKww98SA6enpLFiwgKVLl1K5cmU6deqUM914QkJCzlTnuadTz55KHQqejjw9Pf2I+zzxxBNMnjwZgLlz5wK/tXEsXbqUnj170r17d/7whz9wyy238Kc//Yk+ffqQnp7OmDFjcu6VV7BTsUcCtXH4pW4ruH4B9B4HOz6DiefCf0er95VIHl26dGHfvn05f6wBli9fzrvvvnvEcZmZmRx99NFUrlyZzz77jA8++CCk+wQ7HflNN93EmjVrWLNmDXXq1Dnis3bt2nHVVVfx73//OyemunW9mYGfe+65nOM6dOiQM116eno6tWrV4qijjgopXj8pcfgpLg5aX+PNfdXqavjgSRjfBj5+VYMHRQLMjJkzZ/L222/ToEEDmjZtypgxY373R7tbt24cPHiQ5s2bc9ddd9G2bduQ7jN48GCaNGlCq1atOP3007nhhhtySiOhGDlyJM8++yy7du1izJgxXHrppZx77rnUqlUr55gxY8awYsUKmjdvzqhRo45IKtFA06pHkq2rvJUHt62CE9t7qxGq+kp8pmnVY5OmVY8VdVvB4Heg979h+/pA9dUdsPcXvyMTEckRU4nDzHqb2aTMzChuJ4iLg9aDclVfTfDmvlL1lYhEiJhKHM65Oc65odHSpa1QlWtA78dgyDtwVB2YMQSm9oQfPvU7MhEp52IqccSkuq296qtej8H2T2HiOaq+kjIXi22h5VlJ/z+VOKJBXDykXAu3rPKmcM+pvvqPqq8k7BITE9m5c6eSR4xwzrFz586cQYrFoV5V0WjLSpj7Z9i2Gk48xxs8eIx6vUh4HDhwgC1btuQMppPol5iYyPHHH09CQsIR+4PtVaXEEa0OH4JVz8M7f/eqrdoOh44jITF6BhGJSGRRd9xYl119dfNKaHklLH3CGzy49jVVX4lIWClxRLsqNaHPOK8B/ajj4PXrYWovbxyIiEgYKHHEiuOze189Cj+s83pfzfsr7Nvld2QiEmOUOGJJXDykXOf1vmpxhaqvRCQslDhiUU711QKoeqxXffVcb1VfiUipUOKIZcenwJCF0PNf3qptE8+B+Xeq+kpESkSJI9bFxUOb6wPVV5fD+4+r+kpESkSJo7yoUhP6PO4tHlX1mFzVV5/5HZmIRBkljvKmXhsYsihX9VV7VV+JSEiUOMqjnOqrlXDGwN+qr9a9ruorESmSEkd5VqUWXDjeq76qUhteuw6e7wM7NvgdmYhEMCUO8aqvhqZDz0fgu4/gybNh/l2wb7ffkYlIBFLiEE9cPLQZ7PW+OmMgvD8uUH01Q9VXInIEJQ45Uk711dve69euVfWViBxBiUPyV+9Mr/qqx8O/VV+9fbeqr0REiUMKERcPZw7xpm4/YwC892+v+uqTmaq+EinHlDikaFVrw4VPBKqvasJ/BsHzF8KOjX5HJiI+UOKQ4NU7E4a+G6i+WhOovvqbqq9EyhklDglN7uqr5v3hvcfgiTNVfSVSjihxSPFUrQ19n4Dr5kPlGl711Qt9VX0lUg4ocUjJnHDWb9VXW1er+kqkHFDikJLLrr66ZSU0vyxX9VWaqq9EYlDEJw4z62tmk81slpld4Hc8UoiqtaHvBLhuHiTVgP9cAy9cBD9u8jsyESlFYU0cZjbFzLab2bo8+7uZ2QYz+9zMRhV2DedcmnNuCDAI6B/GcKW0nNDWGzzYfSxsXQUT2gWqrzR1u0gsCHeJYyrQLfcOM4sHngC6A02AgWbWxMyamdkbebZjcp16Z+A8iQbxFeCsoXDLCmh2qVd9Na4lrJgChw76HZ2IlEBYE4dzbjHwU57dZwKfO+e+dM7tB6YDFzrn1jrneuXZtpvnQeAt59yqcMYrYVD1GLjoSRi8EGo2hDdu8xaP2vS22j9EopQfbRx1gW9zvd8S2FeQW4CuwCVmNqygg8xsqJmtMLMVO3bsKJ1IpcTSVm+l/QMLOWn897T/YQQftvk3HNoP0y7x2j++X1f0RUQkoviROCyffQV+9XTOjXPOtXbODXPOTSzkuEnOuRTnXErt2rVLJVApmbTVWxk9Yy1bM7JwwNbMvQz64A/Maj8DUv8J21bDU+fCrJth1/d+hysiQfIjcWwB6uV6fzywzYc4JMzGzttA1oFDR+zLOnCIh97+CtrdCLeuhrOGw0fTYVwrSH8Q9u/xKVoRCVahicPM4s1sQSnfczlwipmdZGYVgQHA7FK+h0SAbRlZhe+vXAO6/QNuXgYNz4P0f8DjrWH1NDh8uAwjFZFQFJo4nHOHgF/NLLk4Fzezl4GlQCMz22Jm1zvnDgI3A/OA9cCrzrlPinP9fO7X28wmZWZmlsblpITqVE8Kbn+Nk6H/C3Dtf+GoOjDrRpjUAb58twyiFJFQmSuiZ4uZvQq0Bd4GcuoRnHO3hje04ktJSXErVqzwO4xyL7uNI3d1VVJCPP/s14y+LQvoD3H4MHwyAxb8HTK/gVO7wfn3Qu1TyyhqkfLLzFY651KKOq5CENd6M7CJhCQ7OYydt4FtGVnUqZ7EiNRGBScNgLg4aHYJNO4FH06E/z0CE9pCyrXQabS3nK2I+KrIEgdAoC0i+yvfBufcgbBGVUIqccSQPT9C+j9hxbNQsQqc+yevQT0h0e/IRGJOsCWOIntVmVknYBPeqO0JwEYz61DiCEWCUaUW9HwEblwKJ7aHBWO85WvXvqYBhCI+CaY77iPABc65js65DkAq8Gh4wxLJo3YjuHw6XD0bkpLh9evh6fPgmw/8jkyk3AkmcSQ45zZkv3HObQQSwhdS8alXVTlwckdv/Y8LJ8Av22BKKrxyFfz0pd+RiZQbwfSqmoI3svuFwK4rgArOuWvDHFuxqY2jnNi/B5Y+AUse86YxOXModLjdGx8iIiErtTYOYDjwCXAr8EfgU6DAOaNEykzFKtDxL3DrKmgxED580puBd+kEOLjf7+hEYlahJY7AFOjPOeeuLLuQSk4ljnLq+3Uw/074cpE3qLDr3+G03mD5TY8WurTVW0PrWiwSZUqlxBEYOV470B1XJLL94XS4aiZc8TrEV4JXr4Jne8DWlSW+9O8mbMzIYvSMtaSt3lryuEWiTDBVVZuB98zsLjP7U/YW5rhEiscMTukKw5ZAr8dg5yaY3AVeHwwZ3xT7sgVN2Dh23oYCzhCJXcEkjm3AG4Fjq+XaIo56VUmO+AreaPNbV8O5t8P6OfB4ijcOZO8vIV+uyAkbRcqRQqccCbRxVHXOjSijeErEOTcHmJOSkjLE71gkQlSqBufd5SWRd+6FJY/Cqheg82hoNchLMEGoUz2JrfkkiYImchSJZcG0cbQqo1hEwif5eOj3FAxNh9qN4c0/w5Nnw8Z5QY1AH5HaiKSE+CP2JSXEMyK1UXjiFYlgwVRVrTGz2WZ2lZn1y97CHplIONRpCYPegAEvweGD8NJl8PyF8P3aQk/r27Iu/+zXjLrVkzCgbvWkwmf5FYlhwQwAfDaf3c45d114Qio5dceVoBw6ACumQPoDkPUztLgCutwJRx3nd2Qivgi2O25Qs+NGGyUOCUlWBvzvYfjwKYirAGffCu1v9QYYipQjJR7HEVjAKfv1g3k+m1+y8EQiSFJ1uOA+uGkZnJoK7z7grYG+6gU4fKjo80XKmcLaOE7J9fr8PJ/VDkMsJabuuFIiNU6CS6fC9W9D9Xow+2Z4qgN8scjvyEQiSmGJo7A6rIis33LOzXHODU1OLtYS6SKeemd6yeOSZ2HfLnihL0y7FLZ/5ndkIhGhsE7slc2sJV5ySQq8tsCmzusS28zg9H7QuKfX9rH4Ya/7butroPNftYStlGsFNo6bWaHlc+dc57BEVArUOC6lbs9OePdBWPGMN6jw/Huh5ZWlNoGiSCRQryolDgmH7Z/BG7fBN+97S9n2etRbnVAkBpTmehwiku2YxjDoTejzOPzwCTzZHhbeDwf2+h2ZSJlR4hAJVVwctLoabl7htYMsfshr//gy3e/IRMqEEodIcVWtDf0mwVVpgPOmLplxA+z50e/IRMIqqMRhZnXN7Gwz65C9hTuw4tA4DvFFg84w/H3oMALWvQ7jU7zBgzHYfigCwc1V9SDQH2+t8exhtM451yfMsRWbGsfFN9s/gzf+D75Z6mvjuZa5leIotV5VZrYBaO6c21dawYWbEof46vBhWPMizL8L9u+Bc26Dc/8MCYllcvvsZW5zr1iYlBCv2XylSKXZq+pLIKHkIYmUEz43nmuZWwm3YBLHr3hrcjxlZuOyt3AHJhL1fGo81zK3Em7BrJs5O7CJSHFkN57/7xFY8hhsmhfWkeda5lbCrcgSh3PuOeBlYGVgeymwT0SClZDkLRI1bIm3dO3sm2FqT9hR+tVHWuZWwq3IxGFmnYBNwBPABGBjpHbHFYl4xzSGQXPDOvJcy9xKuAXTq2olcLlzbkPg/anAy8651mUQX7GoV5VEhd07YP5f4eNXoEYD6PUvOLmT31FJOVaavaoSspMGgHNuI+plJVJyGnkuUSqYxLHCzJ4xs06BbTJeW0fE0chxiUoaeS5RJpiqqkrATcA5eIs4LQYmRPKAQFVVSdSKkJHnUj5pPQ4lDolWPo88l/KrxG0cZvZq4N+1ZvZx3q00gxWRXDRtu0S4wpaOPc45952ZnZjf5865r8MaWQmoxCEx5YtF8Oaf4KcvofkASL1fa55LWJS4xOGc+y7w8kbn3Ne5N+DG0gpURIqgxnOJMMH0qjo/n33dSzsQESlEGY48FylKYW0cw81sLdAoT/vGV4DaOET8UAYjz0WKUlgbRzJwNPBPYFSuj3Y5534qg9iKTW0cUi5o5LmUstJo48h0zm12zg0MtGtkAQ6oamYnlGKsIlIcuUeeu8MaeS5lJphJDnub2SbgK+BdYDPwVpjjEpFgNegMNy5V47mUmWAax+8D2gIbnXMnAecB74U1KhEJTYGN5xv9jkxiUDCJ44BzbicQZ2ZxzrlFQIswxyUixZG38XziOfD+eG80ukgpCSZxZJhZVbw5qqaZ2b+Bg+ENq3g0yaEIv408v2kZNOjiNaA/1wt++srvyCRGBDPJYRVgL94Eh1cAycC0QCkkIqlXlUiAc/DRy/DWSDh8CFLvg9bXhmXJWol+pbYeh3Nuj3PuEFAZmAO8iNe7SkQinRm0uNxrPK/XBt64DV7sB5lb/Y5MolgwvapuMLMf8Ab9rcBbi0Nf50WiSfLxcOVM6PEwfPMBTGgHH01XzysplmDaOG4Hmjrn6jvnTnbOneScOzncgYlIKYuLgzOHeD2vjjkNZt4Ar1wJu7f7HZlEmWASxxfAr+EORETKSM0GcO1cOP9e2PQ2TGgLn87yOyqJIhWCOGY08L6ZfQjkrPrnnLs1bFGJSHjFxUP7W+GU82HmMHj1amh2KXR/CCrX8Ds6iXDBlDieAhYCH+C1b2RvIhLtjjkNBi+ATnfAJzO9to+N8/2OSiJcMCWOg865P4U9EhHxR3wCdBoJp6Z6pY+XLvXGgVxwPyQe5Xd0EoGCKXEsMrOhZnacmdXI3sIemYiUrTot4IZ3of3/weoXvSnbv1rsd1QSgYJJHJcTaOfgt2oqdccViUUVKsH5f4dr/wvxFeC53t7gwf3qHyO/KbKqKjCxoYiUJyec5XXbXfB3+HAifL4A+k70BhFKuVfYCoBdAv/2y28ruxBFxBcVq0CPh+Dq2XBwH0y5wEskB/cVfa7EtMJKHB3xelP1zuczB8wIS0QiEllO7gjD34d5d8CSf8HGeXDRRDiuud+RiU+CmeTwJOfcV0XtiySa5FAkTDbOg9m3wK87oeMoOOc2ry1EYkKpTXIIvJ7PvtdCD0lEot6pqXDjB9CkLyy6D545H3Zs8DsqKWMFflUws8ZAUyA5T5vGUUBiuAMTkQhVuQZc8gyc1gve+BNMPBfOuxvaDvdGpEvMK6yM2QjoBVTnyHaOXcCQcAYlIlGg6UVwYnuY80dvsajP3oS+E6CGOmLGumDaONo555aWUTwlYma9gd4NGzYcsmnTJr/DESkftFhUzCjNNo6LzOwoM0sws3fM7Eczu7IUYix1zrk5zrmhycnJfociUn5osahyJ5jEcYFz7he8aqstwKnAiLBGJSLRJ/l4uCoNej6ixaJiXDCJIyHwbw/gZefcT2GMR0SimRm0GQzD34Njm2ixqBgVTOKYY2afASnAO2ZWG9gb3rBEJKrVOBkGvQkX3FfgYlFpq7fS/oGFnDTqTdo/sJC01araihZFNo4DmNnRwC/OuUNmVgWo5pz7PuzRFZMGAIpEkO2feSWP79bkLBaVtiGL0TPWknXgUM5hSQnx/LNfM/q2rOtjsOVbiRvHzewvud52dc4dAnDO7QG0+p+IBOeYxt5iUZ3/mrNY1JK5Lx2RNACyDhxi7DwNJowGhVVVDcj1enSez7qFIRYRiVXxCdDxLzBkIVSuwcMH7uOfFSZTlSOna9+WkeVTgBKKwhKHFfA6v/ciIkU77gwYms4L8f24LD6d/1YaRbu4T3I+rlM9yb/YJGiFJQ5XwOv83ouIBKdCJar1uo8rD9/DfleBaQn/YFSFlzgq4TAjUhv5HZ0EobApR84ws1/wShdJgdcE3muuKhEpNq8B/GIG//cUrt3zNMMqvMGA5M+pfvzzfocmQQiqV1W0Ua8qkSiz4S2YdRPs3wOp90PK9ZqyxAelOeWIiEh4NeoOw5d6kya++Wd4eQDs3uF3VFIAJQ4RiQzVjoUrXoNuD8IXi+DJs73BgxJxlDhEJHLExUHbYTB0EVSpBdMugbl/gQPqphtJlDhEJPIc2xSGLIKzhsOyp2ByF/jhk6LPkzKhxCEikSkhEbo/AFe+7q1xPqkzfPAkHD7sd2TlnhKHiES2hl1h+PvQ8Dz47yiYdjHsitip8soFJQ4RiXxVasGAl6DXo/D1Um+tj8/e9DuqckuJQ0SigxmkXAc3LPYWjZp+Ocz5P2/sh5QpJQ4RiS61T4XB70D7P8LKqfBUR9i22u+oyhUlDhGJPhUqwvn3wNWzvBLH011hyaNw+FDR50qJKXGISPQ6uaO3TG2jHrBgDDx/IWRu8TuqmKfEISLRrXINuOx5uPAJ2LoKnmzvLRglYaPEISLRzwxaXgnD/gc1G8B/BkHajbBvl9+RxSQlDhGJHTUbwHXzoMNf4KOXYeI58O1yv6OKOUocIhJb4hOuLhcCAAANrklEQVSgy19h0FxvlPmUVHj3ITh00O/IYkbEJw4zO83MJprZa2Y23O94RCRKnNgOhi+B0y+GRffD1J7w82a/o4oJYU0cZjbFzLab2bo8+7uZ2QYz+9zMRhV2DefceufcMOAyoMgFRkREciQmw8WTod9k2P4pPHkOfPSK31FFvXCXOKYC3XLvMLN44AmgO9AEGGhmTcysmZm9kWc7JnBOH2AJ8E6Y4xWRWNT8Mhi2xJt1d+ZQeH0wZGX4HVXUCmvicM4tBn7Ks/tM4HPn3JfOuf3AdOBC59xa51yvPNv2wHVmO+fOBq4IZ7wiEsOOPhEGvQmd74R1M2DiufD1+35HFZX8aOOoC3yb6/2WwL58mVknMxtnZk8Bcws5bqiZrTCzFTt2aMlJEclHfAXoOAKunw9x8V67xzv3wqEDfkcWVSr4cM/8VqB3BR3snEsH0ou6qHNuEjAJICUlpcDriYhwfIo35uO/o+B/D8MXC+Hip73uvFIkP0ocW4B6ud4fD2zzIQ4RKc8qVfNGm1/6HPz0pVd1teoFcPreWRQ/Esdy4BQzO8nMKgIDgNk+xCEiAk37egtF1W0Fs2+GV6+GX/M2zUpu4e6O+zKwFGhkZlvM7Hrn3EHgZmAesB541TmnxYRFxD/JdeHq2d6MuxvegifPhi/T/Y4qYpmLoWKZmfUGejds2HDIpk2b/A5HRKLRtjVed92dn8PZtzC7xnU8uOArtmVkUad6EiNSG9G3ZYH9eaKama10zhU5Xi7iR46Hwjk3xzk3NDk52e9QRCRa1WnhrTKYci28P46Gc/qSmPk5DtiakcXoGWtJW73V7yh9FVOJQ0SkVFSsDL0eZWTCaI5lJ29WvIMr4hcAjqwDhxg7b4PfEfpKiUNEpACv7mpGt30PsuxwY+5PmMLEhMdIZjfbMrL8Ds1XShwiIgWoUz2JHVTnmgMjue/AFXSJW8VblUbR46gv/A7NVzGVOMyst5lNyszM9DsUEYkBI1IbkZQQjyOOpw/1pN/+v7OfSozffzcsvK/cTtUeU4lDjeMiUpr6tqzLP/s1o271JAz4Obkpa3vNxlpcDovHwrPd4eev/Q6zzMVUd9xsKSkpbsWKFX6HISKxbO1r8MZtgEHvR711P6JcueyOKyJSZppd4s13VftUeO06SLsJ9u32O6oyocQhIlJcR9eHa9+Cc2+HNdNgUkdvAGGMU+IQESmJ+AQ47y64Zg7s/xWe7grvj/fWO49RMZU41KtKRHxz0rkw/D045QKY/1d46VLYvd3vqMIiphKHelWJiK8q14AB06DnI7B5iTdZ4ucL/I6q1MVU4hAR8Z0ZtBkMQxZBldrw4sUw769wcJ/fkZUaJQ4RkXA4tgkMWQhthsDS8V7bx4+xMWu3EoeISLgkJEHPh2HAS5D5LTzVAVa/GPWrDCpxiIiEW+OegVUGW8Osm7xxH1kZfkdVbEocIiJl4ag6cPUsOO9u+HSWt8b5Nx/6HVWxxFTiUHdcEYlocfFw7p/hunleI/qz3eHdh+DwIb8jC0lMJQ51xxWRqFCvjTddSdOLYNH98FwfyIyeVQVjKnGIiESNxGS4+Gno+yRsW+2N+Vg/x++ogqLEISLiFzNocblX+ji6PrxypTfj7v5f/Y6sUEocIiJ+q9kArn8bzr4VVkyByZ3hh0/8jqpAShwiIpGgQkW44F64aiZk/QyTOsOyyRE55kOJQ0QkkjToAsPeg5M7wtzbYfrlsGen31EdQYlDRCTSVK0Nl78K3R7wJkmc2B6+fNfvqHLEVOLQOA4RiRlm0HY4DH4HKlaF5y+EBWPg0AG/I4utxKFxHCISc45rDje8C62ugiWPwpRU+OlLX0OKqcQhIhKTKlaBPo/Dpc/Bzs9hYgf4+FXfwqng251FRCQ0Tft6EyXOGOJtXyyEHmNJ+/QXxs7bwLaMLOpUT2JEaiP6tqwbtjCUOEREokn1enDNG7B4LCx+iN2fv8e0X25g64GTANiakcXoGWsBwpY8VFUlIhJt4itA59Ew6E127/mVl+Lu5ob4ORiHAcg6cIix8zaE7fZKHCIi0erEs0nd+w/mH27N6ISXeT7hAWrzMwDbMrLCdlslDhGRKFa1em1uOvBHRh4YQsO4bSTgTdFep3pS2O6pxCEiEsVGpDYiKaECrxzqTKd9/2IbtUhKiGdEaqOw3VON4yIiUSy7AdzrVQV11atKRESK0rdl3bAmirxiqqpKU46IiIRfTCUOTTkiIhJ+MZU4REQk/JQ4REQkJEocIiISEiUOEREJibkIXM+2pMxsB5ABFNS9KrmQz2oBP4YjrjAo7OeItHsU9zqhnhfM8UUdU9zP9eyE7z5l8fyUxrNT1DGR/rfnROdc7SKPcs7F5AZMKuZnK/yOvTR+xki7R3GvE+p5wRxf1DHF/VzPTnQ/P6Xx7BR1TKz87Ynlqqo5xfwsmpTFz1Fa9yjudUI9L5jjizqmpJ9Hg7L6GaLp+SmNZ6eoY2Lh2YnNqqqSMLMVzrkUv+OQ6KNnR0oimp6fWC5xFNckvwOQqKVnR0oiap4flThERCQkKnGIiEhIlDhERCQkShwiIhISJY4imFlfM5tsZrPM7AK/45HoYWanmdlEM3vNzIb7HY9EFzOrYmYrzayX37HkVS4Th5lNMbPtZrYuz/5uZrbBzD43s1EAzrk059wQYBDQ34dwJYKE+Oysd84NAy4DoqKbpYRPKM9OwEjg1bKNMjjlMnEAU4FuuXeYWTzwBNAdaAIMNLMmuQ65M/C5lG9TCeHZMbM+wBLgnbINUyLQVIJ8dsysK/Ap8ENZBxmMcpk4nHOLgZ/y7D4T+Nw596Vzbj8wHbjQPA8CbznnVpV1rBJZQnl2AsfPds6dDVxRtpFKpAnx2ekMtAUuB4aYWUT9rdaa47+pC3yb6/0W4CzgFqArkGxmDZ1zE/0ITiJavs+OmXUC+gGVgLk+xCWRL99nxzl3M4CZDQJ+dM4d9iG2Ailx/Mby2eecc+OAcWUdjESVgp6ddCC9bEORKJPvs5PzwrmpZRdK8CKq+OOzLUC9XO+PB7b5FItEFz07UlxR+ewocfxmOXCKmZ1kZhWBAcBsn2OS6KBnR4orKp+dcpk4zOxlYCnQyMy2mNn1zrmDwM3APGA98Kpz7hM/45TIo2dHiiuWnh1NcigiIiEplyUOEREpPiUOEREJiRKHiIiERIlDRERCosQhIiIhUeIQEZGQKHFIxDEzZ2aP5Hp/u5mNKaVrTzWzS0rjWkXc51IzW29mi8J9r8D9BpnZ+DBeP+f3ZmbpZqZp4ssxJQ6JRPuAfmZWy+9AcgtMgR2s64EbnXOdw3wfkTKnxCGR6CAwCbgt7wd5Swxmtjvwbycze9fMXjWzjWb2gJldYWbLzGytmTXIdZmuZva/wHG9AufHm9lYM1tuZh+b2Q25rrvIzF4C1uYTz8DA9dcFpt/HzO4GzgEmmtnYPMdb4D7rAuf1L+g+ZpYWWAHuEzMbmusa3cxslZl9ZGa/W+fDzGqb2euBn2W5mbXP55h4M3s4EMPHZnZLduyBc9aZ2SQzy28SvtzXmJrrZ/nd/5fEJs2OK5HqCeBjM3sohHPOAE7DW/PgS+Bp59yZZvZHvOnx/y9wXH2gI9AAWGRmDYGrgUznXBszqwS8Z2bzA8efCZzunPsq983MrA7wINAa+BmYb2Z9nXP3mFkX4Hbn3Io8MfYDWgRirQUsN7PFBdznOufcT2aWFDjudbwve5OBDs65r8ysRj6/h38DjzrnlpjZCXjTWZyW55ihwElAS+fcwVzXGe+cuyfw870A9ALm5HMPAj9HXefc6YHjqxdwnMQYJQ6JSM65X8zseeBWICvI05Y7574DMLMvgOw//GvxFsbJ9mpgfYNNZvYl0Bi4AGieqzSTDJwC7AeW5U0aAW2AdOfcjsA9pwEdgLRCYjwHeNk5dwj4wczeDVznl3zuc6uZXRR4XS8QT21gcfZxzrm8CwOBt35Mk1yFhaPMrJpzbleeYyYG5krKfZ3OZvYXoDJQA/iEghPHl8DJZvY48Ca//b4lxilxSCR7DFgFPJtr30ECVayBapSKuT7bl+v14VzvD3Pks553gjaHty7CLc65ebk/MG8xpj0FxFdgNU4hCjsn5z6B+3YF2jnnfjWzdCAxcH5RE8zFBc4rLOH+7jpmlghMAFKcc98GOiQkFnQB59zPZnYGkArchLe2+nVFxCYxQG0cErEC34JfxWtozrYZr2oIvCU2E4px6UvNLC7Q7nEysAGvOme4mSUAmNmpZlaliOt8CHQ0s1qBBu2BwLtFnLMY6B9oH6iNV0JZls9xycDPgaTRGG8ZUfBmV+1oZicF4syvqmo+3oyrBI5pUcAxw8ysQq7rZCeJH82sKlBo77NA54U459zrwF1Aq8KOl9ihEodEukfI9UcQr35/lpktA96h4NJAYTbg/YE/FhjmnNtrZk/jtX2sCpRkdgB9C7uIc+47MxsNLML7Bj/XOTeriHvPBNoBH+F94/+Lc+77QHLI7b94f9g/DsT7QeCeOwIN5TPMW4d6O3B+nnNvBZ4InFsBL1kNy3PM08CpeO1IB4DJzrnxZjYZr2pvM95aEYWpCzxrv62HPbqI4yVGaFp1EREJiaqqREQkJEocIiISEiUOEREJiRKHiIiERIlDRERCosQhIiIhUeIQEZGQKHGIiEhI/h/Lo8JBJNK+PAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x22fde323e80>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "p1 = plt.plot(OracleCall_list, error_list, 'o')\n",
+    "p2 = plt.plot(OracleCall_list, ErrorCramérRao_list)\n",
+    "plt.xscale('log')\n",
+    "plt.xlabel(\"Number of oracle calls\")\n",
+    "plt.yscale('log')\n",
+    "plt.ylabel(\"Estimation Error\")\n",
+    "plt.legend((p1[0], p2[0]), (\"Estimated Value\", \"Cramér-Rao\"))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see that the above algorithm achieved almost as good as the lower bound provided by the Cramér-Rao bound. "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I added a notebook of "SimpleIntegral_AEwoPE.ipynb".
This notebook contains experiments for performing amplitude estimation without inverse Quantum Fourier Transform (QFT) and controlled Q-operators (aka., Grover operators). It is known that without QFT and such controlled operators, the number of two-qubit gates (e.g., CNOT gates) required for running amplitude estimation can be reduced, and hence may be more appropriate to run quantum algorithms on Noisy Intermediate Scale Quantum (NISQ) devices.


### Details and comments

