### PR TITLE
New Script on Basis Gate Decomposition of Single-Qubit Operators and Their Controlled Versions

### DIFF
--- a/terra/qis_intro/Basis_Gate_Decomposition_of_Arbitrary_Single_Qubit_Operators.ipynb
+++ b/terra/qis_intro/Basis_Gate_Decomposition_of_Arbitrary_Single_Qubit_Operators.ipynb
@@ -1,0 +1,736 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"qiskit_logo.png\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basis Gate Decomposition of Arbitrary Single-Qubit Unitary Operators\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Contributors\n",
+    "Bruno Murta, Quantalab, International Iberian Nanotechnology Laboratory (INL)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## QISKit Package Versions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 406,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'qiskit-terra': '0.9.0',\n",
+       " 'qiskit-ignis': '0.2.0',\n",
+       " 'qiskit-aqua': '0.6.0',\n",
+       " 'qiskit': '0.12.0',\n",
+       " 'qiskit-aer': '0.3.0',\n",
+       " 'qiskit-ibmq-provider': '0.3.2'}"
+      ]
+     },
+     "execution_count": 406,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import qiskit\n",
+    "qiskit.__qiskit_version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Implementing quantum algorithms in quantum hardware requires their conversion into a quantum circuit. In practice, this means decomposing a unitary matrix into a sequence of basis gates. Accomplishing this for any unitary matrix is therefore a valuable skill in quantum computing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook, it is explained how to find the basis gate decomposition of any 2x2 unitary matrix, as well as of the respective controlled version."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Implementation of Arbitrary 2x2 Unitary Matrix via $U_3$ Gate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most single-qubit gates used in quantum algorithms can be immediately written in terms of Clifford gates or rotations around the cartesian axes of the Bloch sphere. However, in general this decomposition may not be obvious. The QISKit basis gate $U_3$ allows to implement any 2x2 unitary matrix, though:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\n",
+    "\\begin{split}\n",
+    "    & U_3(\\theta, \\phi, \\lambda) = \\left( \\begin{matrix} \\cos(\\theta/2) & -e^{i \\lambda} \\sin(\\theta/2) \\\\ e^{i\\phi} \\sin(\\theta/2) & e^{i(\\lambda + \\phi)} \\cos(\\theta/2) \\end{matrix} \\right) \n",
+    "\\end{split}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A general expression for a 2x2 unitary matrix is:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\n",
+    "\\begin{split}\n",
+    "    & \\mathcal{U} = \\left( \\begin{matrix} a & b \\\\ -e^{i\\eta} b^{*} & e^{i\\eta} a^{*} \\end{matrix} \\right),\n",
+    "\\end{split}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "with $|a|^2 + |b|^2 = 1$ and $\\textrm{det}(\\mathcal{U}) = e^{i\\eta}$. The two matrices can be equated, giving:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\\theta = 2 \\arctan\\Big(\\frac{|b|}{|a|}\\Big) \\\\\n",
+    "  \\lambda = -\\pi + \\textrm{arg}(b) - \\textrm{arg}(a)\\\\\n",
+    "  \\phi = \\pi + \\eta - \\textrm{arg}(a) - \\textrm{arg}(b)$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "where $a = |a| \\; e^{i\\textrm{arg}(a)}$ and similarly for $b$. We can now define a function that generates this two-gate decomposition corresponding to a given 2x2 unitary matrix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 407,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def is_unitary(A):\n",
+    "    '''\n",
+    "    Function that determines if A is a unitary matrix\n",
+    "    U: Unitary matrix of any size [numpy.ndarray]\n",
+    "    '''\n",
+    "    \n",
+    "    return np.allclose(np.eye(A.shape[0]), A.dot(np.transpose(np.conjugate(A))))\n",
+    "\n",
+    "def find_params(U):\n",
+    "    '''\n",
+    "    Function that finds parameters of U3 that implement unitary matrix U up to global phase\n",
+    "    U: Unitary 2x2 matrix [numpy.ndarray]\n",
+    "    '''\n",
+    "    \n",
+    "    # Checking if input is numpy.ndarray\n",
+    "    if not type(U) is np.ndarray:\n",
+    "        sys.exit(\"Input must be numpy.ndarray\")\n",
+    "    \n",
+    "    # Checking if input has right dimensionality\n",
+    "    if not U.shape == (2,2):\n",
+    "        sys.exit(\"Input must be 2x2 matrix\")\n",
+    "        \n",
+    "    # Checking if input is unitary\n",
+    "    if not is_unitary(U):\n",
+    "        sys.exit(\"Input must be unitary\")\n",
+    "    \n",
+    "    a = U[0,0]\n",
+    "    b = U[0,1]\n",
+    "    eta = np.angle(U[1,1]/(np.conjugate(a)))\n",
+    "    \n",
+    "    theta = 2*np.arctan(np.absolute(b)/np.absolute(a))\n",
+    "    lamda = -cmath.pi - np.angle(a) + np.angle(b)\n",
+    "    phi = cmath.pi + eta - np.angle(a) - np.angle(b)\n",
+    "    \n",
+    "    params = [theta, phi, lamda]\n",
+    "    \n",
+    "    return params\n",
+    "\n",
+    "def u3_given_matrix(U):\n",
+    "    '''\n",
+    "    Function that outputs U3 gate that implement unitary matrix U\n",
+    "    U: Unitary 2x2 matrix [numpy.ndarray]\n",
+    "    '''\n",
+    "    \n",
+    "    [theta, phi, lamda] = find_params(U)\n",
+    "    \n",
+    "    qc = QuantumCircuit(1)\n",
+    "    qc.u3(theta,phi,lamda,0)\n",
+    "    \n",
+    "    # Sanity check to accuracy set by f_acc\n",
+    "    f_acc = 1e-6\n",
+    "    \n",
+    "    simulator = Aer.get_backend('unitary_simulator')\n",
+    "    result = execute(qc, simulator).result()\n",
+    "    u3_out = result.get_unitary(qc)\n",
+    "    \n",
+    "    numerator = (np.trace(np.matmul(np.conjugate(np.transpose(U)), u3_out)))**2\n",
+    "    denominator = np.trace(np.matmul(np.conjugate(np.transpose(U)), U)) * np.trace(np.matmul(np.conjugate(np.transpose(u3_out)), u3_out))\n",
+    "    fidelity_measure = numerator / denominator\n",
+    "        \n",
+    "    if 1 - abs(fidelity_measure) < f_acc:\n",
+    "        return qc\n",
+    "    else:\n",
+    "        sys.exit(\"Could not obtain ZYZ decomposition to desired accuracy\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us test this function for a randomly generated 2x2 unitary matrix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 413,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[-0.09193753-0.99576478j -0.09193753-0.99576478j]\n",
+      " [-0.09193753-0.99576478j -0.09193753-0.99576478j]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def arbitrary_unitary():\n",
+    "    '''\n",
+    "    Function that generates random unitary 2x2 matrix\n",
+    "    '''\n",
+    "    \n",
+    "    mod_a = random.random()\n",
+    "    mod_b = cmath.sqrt(1 - mod_a**2)\n",
+    "    arg_a = random.random()*2*cmath.pi\n",
+    "    arg_b = random.random()*2*cmath.pi\n",
+    "    eta = random.random()*2*cmath.pi\n",
+    "    \n",
+    "    a = mod_a*cmath.exp(1j*arg_a)\n",
+    "    b = mod_b*cmath.exp(1j*arg_b)\n",
+    "    \n",
+    "    U = np.array([[a, b], [-cmath.exp(1j*eta)*np.conjugate(b), cmath.exp(1j*eta)*np.conjugate(a)]])\n",
+    "    \n",
+    "    return U\n",
+    "\n",
+    "U = arbitrary_unitary()\n",
+    "qc = u3_given_matrix(U)\n",
+    "\n",
+    "# Sanity check\n",
+    "simulator = qiskit.Aer.get_backend('unitary_simulator')\n",
+    "result = execute(qc, simulator).result()\n",
+    "output_u3 = result.get_unitary(qc)\n",
+    "\n",
+    "print(np.divide(output_u3, U))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As expected, the original matrix and its corresponding $U_3$ gate only differ by a redundant global phase."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Implementation of Arbitrary 2x2 Unitary Matrix via ZYZ Decomposition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, the quantum circuit for a given 2x2 unitary matrix can be obtained via the ZYZ decomposition [1]:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\n",
+    "\\begin{split}\n",
+    "    & \\mathcal{U} = e^{i\\alpha} \\textbf{R}_z(\\beta) \\textbf{R}_y(\\gamma) \\textbf{R}_z(\\delta) = \\\\\n",
+    "    & = \\left( \\begin{matrix} e^{i(\\alpha - \\beta/2 - \\delta/2)} \\cos\\frac{\\gamma}{2} & -e^{i(\\alpha - \\beta/2 + \\delta/2)} \\sin\\frac{\\gamma}{2} \\\\ e^{i(\\alpha + \\beta/2 - \\delta/2)} \\sin\\frac{\\gamma}{2} & e^{i(\\alpha + \\beta/2 + \\delta/2)} \\cos\\frac{\\gamma}{2} \\end{matrix} \\right),\n",
+    "\\end{split}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Equating this matrix to the general form of a 2x2 unitary matrix stated above gives:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\\alpha = \\frac{\\eta}{2} \\\\\n",
+    "  \\beta = \\pi + \\eta - \\textrm{arg}(a) - \\textrm{arg}(b)\\\\\n",
+    "  \\gamma = 2 \\arctan\\Big(\\frac{|b|}{|a|}\\Big)\\\\\n",
+    "  \\delta = -\\pi + \\textrm{arg}(b) - \\textrm{arg}(a)$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us now define a function that implements the ZYZ decomposition of an arbitrary 2x2 unitary matrix and outputs the corresponding quantum circuit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 415,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ZYZ_decompose(U):\n",
+    "    '''\n",
+    "    Function that finds parameters of ZYZ decomposition of U\n",
+    "    U: 2x2 unitary matrix [numpy.ndarray]\n",
+    "    '''\n",
+    "    \n",
+    "    # Checking if input is numpy.ndarray\n",
+    "    if not type(U) is np.ndarray:\n",
+    "        sys.exit(\"Input must be numpy.ndarray\")\n",
+    "    \n",
+    "    # Checking if input has right dimensionality\n",
+    "    if not U.shape == (2,2):\n",
+    "        sys.exit(\"Input must be 2x2 matrix\")\n",
+    "        \n",
+    "    # Checking if input is unitary\n",
+    "    if not is_unitary(U):\n",
+    "        sys.exit(\"Input must be unitary\")\n",
+    "    \n",
+    "    a = U[0,0]\n",
+    "    b = U[0,1]\n",
+    "    eta = np.angle(U[1,1]/(np.conjugate(a)))\n",
+    "    \n",
+    "    alpha = 0.5*eta\n",
+    "    beta = cmath.pi + eta - np.angle(a) - np.angle(b)\n",
+    "    gamma = 2*np.arctan(np.absolute(b)/np.absolute(a))\n",
+    "    delta = -cmath.pi + np.angle(b) - np.angle(a)\n",
+    "    \n",
+    "    params = [alpha, beta, gamma, delta]\n",
+    "    \n",
+    "    return params  \n",
+    "    \n",
+    "\n",
+    "def ZYZ_circuit(U):\n",
+    "    '''\n",
+    "    Function that finds quantum circuit that implements U based on ZYZ decomposition\n",
+    "    U: 2x2 unitary matrix [numpy.ndarray]\n",
+    "    '''\n",
+    "    \n",
+    "    [alpha, beta, gamma, delta] = ZYZ_decompose(U)\n",
+    "    \n",
+    "    qc = QuantumCircuit(1)\n",
+    "    qc.rz(delta,0)\n",
+    "    qc.ry(gamma,0)\n",
+    "    qc.rz(beta,0)\n",
+    "    \n",
+    "    # Sanity check to accuracy set by f_acc\n",
+    "    f_acc = 1e-6\n",
+    "    \n",
+    "    simulator = Aer.get_backend('unitary_simulator')\n",
+    "    result = execute(qc, simulator).result()\n",
+    "    ZYZ = result.get_unitary(qc)\n",
+    "    \n",
+    "    numerator = (np.trace(np.matmul(np.conjugate(np.transpose(U)), ZYZ)))**2\n",
+    "    denominator = np.trace(np.matmul(np.conjugate(np.transpose(U)), U)) * np.trace(np.matmul(np.conjugate(np.transpose(ZYZ)), ZYZ))\n",
+    "    fidelity_measure = numerator / denominator\n",
+    "        \n",
+    "    if 1 - abs(fidelity_measure) < f_acc:\n",
+    "        return qc\n",
+    "    else:\n",
+    "        sys.exit(\"Could not obtain ZYZ decomposition to desired accuracy\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now check that our function works for an arbitrary unitary matrix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 436,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.97371918-0.22775195j 0.97371918-0.22775195j]\n",
+      " [0.97371918-0.22775195j 0.97371918-0.22775195j]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "U = arbitrary_unitary()\n",
+    "qc = ZYZ_circuit(U)\n",
+    "\n",
+    "# Sanity check\n",
+    "simulator = qiskit.Aer.get_backend('unitary_simulator')\n",
+    "result = execute(qc, simulator).result()\n",
+    "output_ZYZ = result.get_unitary(qc)\n",
+    "\n",
+    "print(np.divide(output_ZYZ, U))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controlled Single-Qubit Gates via $U_3$ Gate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The controlled version of a unitary 2x2 matrix U can be straightforwardly implemented by taking advantage of the QISKit built-in function _cu3_. There is, however, a caveat that must be considered first: a controlled-U gate is sensitive to the global phase of U, so we cannot disregard global phase factors in the basis gate decomposition of U, as we did earlier when using the $U_3$ gate. We must therefore add an extra parameter, which can be introduced via a $R_z$ gate:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\n",
+    "\\begin{split}\n",
+    "    & U_3(\\theta, \\phi, \\lambda) R_z(2\\mu) = \\left( \\begin{matrix} \\cos(\\theta/2) & -e^{i \\lambda} \\sin(\\theta/2) \\\\ e^{i\\phi} \\sin(\\theta/2) & e^{i(\\lambda + \\phi)} \\cos(\\theta/2) \\end{matrix} \\right)\n",
+    "    \\left( \\begin{matrix} e^{-i\\mu} & 0 \\\\ 0 & e^{i\\mu} \\end{matrix} \\right) =\n",
+    "    \\left( \\begin{matrix} e^{-i\\mu} \\cos(\\theta/2) & -e^{i(\\lambda + \\mu)} \\sin(\\theta/2) \\\\ e^{i(\\phi - \\mu)} \\sin(\\theta/2) & e^{i(\\lambda + \\phi + \\mu)} \\cos(\\theta/2) \\end{matrix} \\right)\n",
+    "\\end{split}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parameters are given by:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\\theta = 2 \\arctan\\Big(\\frac{|b|}{|a|}\\Big) \\\\\n",
+    "  \\lambda = -\\pi + \\textrm{arg}(a) + \\textrm{arg}(b)\\\\\n",
+    "  \\phi = \\pi + \\eta - \\textrm{arg}(a) - \\textrm{arg}(b)\\\\\n",
+    "  \\mu = -\\textrm{arg}(a)$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The controlled-U gate is obtained by simply taking the controlled versions of both $R_z$ and $U_3$ gates:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"fig2.png\">"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 437,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def controlled_matrix(U):\n",
+    "    '''\n",
+    "    Function that finds 4x4 matrix that represents controlled-U\n",
+    "    U: 2x2 unitary matrix [numpy.ndarray]\n",
+    "    '''\n",
+    "    \n",
+    "    top_cU = np.hstack((np.eye(2), np.zeros([2,2])))\n",
+    "    bottom_cU = np.hstack((np.zeros([2,2]),U))\n",
+    "    cU = np.vstack((top_cU,bottom_cU))\n",
+    "    \n",
+    "    return cU\n",
+    "\n",
+    "def find_params_2(U):\n",
+    "    '''\n",
+    "    Function that finds parameters of U3 and Rz that implement unitary matrix U exactly\n",
+    "    U: Unitary 2x2 matrix [numpy.ndarray]\n",
+    "    '''\n",
+    "    \n",
+    "    # Checking if input is numpy.ndarray\n",
+    "    if not type(U) is np.ndarray:\n",
+    "        sys.exit(\"Input must be numpy.ndarray\")\n",
+    "    \n",
+    "    # Checking if input has right dimensionality\n",
+    "    if not U.shape == (2,2):\n",
+    "        sys.exit(\"Input must be 2x2 matrix\")\n",
+    "        \n",
+    "    # Checking if input is unitary\n",
+    "    if not is_unitary(U):\n",
+    "        sys.exit(\"Input must be unitary\")\n",
+    "    \n",
+    "    a = U[0,0]\n",
+    "    b = U[0,1]\n",
+    "    eta = np.angle(U[1,1]/(np.conjugate(a)))\n",
+    "    \n",
+    "    theta = 2*np.arctan(np.absolute(b)/np.absolute(a))\n",
+    "    lamda = -cmath.pi + np.angle(a) + np.angle(b)\n",
+    "    phi = cmath.pi + eta - np.angle(a) - np.angle(b)\n",
+    "    mu = -np.angle(a)\n",
+    "    \n",
+    "    params = [theta, phi, lamda, mu]\n",
+    "    \n",
+    "    return params\n",
+    "\n",
+    "def controlled_gate_circuit(U):\n",
+    "    '''\n",
+    "    Function that outputs U3 gate that implement unitary matrix U\n",
+    "    U: Unitary 2x2 matrix [numpy.ndarray]\n",
+    "    '''\n",
+    "    \n",
+    "    [theta, phi, lamda, mu] = find_params_2(U)\n",
+    "    \n",
+    "    qc = QuantumCircuit(2)\n",
+    "    qc.crz(2*mu,1,0)\n",
+    "    qc.cu3(theta,phi,lamda,1,0)\n",
+    "    \n",
+    "    # Sanity check to accuracy set by f_acc\n",
+    "    f_acc = 1e-6\n",
+    "    \n",
+    "    simulator = Aer.get_backend('unitary_simulator')\n",
+    "    result = execute(qc, simulator).result()\n",
+    "    u3_out = result.get_unitary(qc)\n",
+    "    \n",
+    "    cU = controlled_matrix(U)\n",
+    "    \n",
+    "    numerator = (np.trace(np.matmul(np.conjugate(np.transpose(cU)), u3_out)))**2\n",
+    "    denominator = np.trace(np.matmul(np.conjugate(np.transpose(cU)), cU)) * np.trace(np.matmul(np.conjugate(np.transpose(u3_out)), u3_out))\n",
+    "    fidelity_measure = numerator / denominator\n",
+    "        \n",
+    "    if 1 - abs(fidelity_measure) < f_acc:\n",
+    "        return qc\n",
+    "    else:\n",
+    "        sys.exit(\"Could not obtain ZYZ decomposition to desired accuracy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 452,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "U = arbitrary_unitary()\n",
+    "qc = controlled_gate_circuit(U)\n",
+    "\n",
+    "# Sanity check\n",
+    "simulator = qiskit.Aer.get_backend('unitary_simulator')\n",
+    "result = execute(qc, simulator).result()\n",
+    "output_u3 = result.get_unitary(qc)\n",
+    "\n",
+    "cU = controlled_matrix(U)\n",
+    "\n",
+    "numerator = (np.trace(np.matmul(np.conjugate(np.transpose(output_u3)), cU)))**2\n",
+    "denominator = np.trace(np.matmul(np.conjugate(np.transpose(output_u3)), output_u3)) * np.trace(np.matmul(np.conjugate(np.transpose(cU)), cU))\n",
+    "fidelity_measure = abs(numerator / denominator)\n",
+    "\n",
+    "print(fidelity_measure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controlled Single-Qubit Gates via ZYZ Decomposition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A single-qubit gate can also be easily converted into its controlled version via the ZYZ decomposition [1]:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"fig1.png\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "where $\\alpha$, $\\beta$, $\\gamma$ and $\\delta$ are the parameters of the ZYZ decomposition found above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 454,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def controlled_gate_circuit_2(U):\n",
+    "    '''\n",
+    "    Function that finds quantum circuit that implements controlled-U based on ZYZ decomposition\n",
+    "    U: 2x2 unitary matrix [numpy.ndarray]\n",
+    "    '''\n",
+    "    \n",
+    "    [alpha, beta, gamma, delta] = ZYZ_decompose(U)\n",
+    "    \n",
+    "    qc = QuantumCircuit(2)\n",
+    "    qc.rz(0.5*(delta-beta),0)\n",
+    "    qc.cx(1,0)\n",
+    "    qc.rz(-0.5*(delta+beta),0)\n",
+    "    qc.ry(-0.5*gamma,0)\n",
+    "    qc.cx(1,0)\n",
+    "    qc.ry(0.5*gamma,0)\n",
+    "    qc.rz(beta,0)\n",
+    "    qc.rz(alpha,1)\n",
+    "    \n",
+    "    # Sanity check to accuracy set by f_acc\n",
+    "    f_acc = 1e-6\n",
+    "    \n",
+    "    simulator = Aer.get_backend('unitary_simulator')\n",
+    "    result = execute(qc, simulator).result()\n",
+    "    ZYZ = result.get_unitary(qc)\n",
+    "        \n",
+    "    cU = controlled_matrix(U)\n",
+    "    numerator = (np.trace(np.matmul(np.conjugate(np.transpose(cU)), ZYZ)))**2\n",
+    "    denominator = np.trace(np.matmul(np.conjugate(np.transpose(cU)), cU)) * np.trace(np.matmul(np.conjugate(np.transpose(ZYZ)), ZYZ))\n",
+    "    fidelity_measure = numerator / denominator\n",
+    "        \n",
+    "    if 1 - abs(fidelity_measure) < f_acc:\n",
+    "        return qc\n",
+    "    else:\n",
+    "        sys.exit(\"Could not obtain controlled-U to desired accuracy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 458,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "U = arbitrary_unitary()\n",
+    "qc = controlled_gate_circuit_2(U)\n",
+    "\n",
+    "# Sanity check\n",
+    "simulator = qiskit.Aer.get_backend('unitary_simulator')\n",
+    "result = execute(qc, simulator).result()\n",
+    "output_ZYZ = result.get_unitary(qc)\n",
+    "\n",
+    "qc_init = QuantumCircuit(2)\n",
+    "cU = controlled_matrix(U)\n",
+    "opts = {\"initial_unitary\": cU}\n",
+    "result_init = execute(qc_init, simulator, backend_options=opts).result()\n",
+    "output_init = result_init.get_unitary(qc_init)\n",
+    "\n",
+    "numerator = (np.trace(np.matmul(np.conjugate(np.transpose(output_ZYZ)), output_init)))**2\n",
+    "denominator = np.trace(np.matmul(np.conjugate(np.transpose(output_ZYZ)), output_ZYZ)) * np.trace(np.matmul(np.conjugate(np.transpose(output_init)), output_init))\n",
+    "fidelity_measure = abs(numerator / denominator)\n",
+    "\n",
+    "print(fidelity_measure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[1] M. A. Nielsen and I. L. Chuang, _Quantum Computation and Quantum Information - 10th Anniversary Edition_ (Cambridge University Press)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/terra/qis_intro/README.md
+++ b/terra/qis_intro/README.md
@@ -13,6 +13,8 @@ differently from a probabilistic bit.
 
 * [Teleportation and Superdense Coding](teleportation_superdensecoding.ipynb): shows how quantum entanglement can be used to teleport (sending quantum information without moving) a qubit, and encode two-bit of information in a qubit.
 
+* [Basis Gate Decomposition of Arbitrary Single-Qubit Operators and Their Controlled Versions](Basis_Gate_Decomposition_of_Arbitrary_Single_Qubit_Operators.ipynb): shows how to find basis gate decomposition of arbitrary 2x2 unitary matrix and its 4x4 controlled version via two methods: using the built-in U3 gate, on the one hand, and performing the ZYZ decomposition, on the other.
+
 
 ## Contributing
 


### PR DESCRIPTION
### Summary
I added a new script to the qis_intro section. This script explains how to decompose an arbitrary 2x2 unitary matrix and its 4x4 controlled version in terms of basis gates.


### Details and comments
I explored two methods, one using the U3 basis gate and another involving the ZYZ decomposition as outlined in Nielsen & Chuang. Both methods were tested using randomly generated unitary matrices.

