### PR TITLE
Update codeowners for Aqua

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,11 +8,11 @@ algorithms/* @attp @aasfaw @quantumjim @rraymondhp
 aer/* @chriseclectic @attp @aasfaw @quantumjim @rraymondhp
 ignis/* @dcmckayibm @yehuda-naveh @attp @aasfaw @quantumjim @rraymondhp
 
-aqua/**/* @chunfuchen @pistoia @aasfaw
-machine_learning/**/* @chunfuchen @pistoia @aasfaw
-chemistry/**/* @chunfuchen @pistoia @aasfaw
-finance/**/* @chunfuchen @pistoia @aasfaw
-optimization/**/* @chunfuchen @pistoia @aasfaw
+aqua/**/* @woodsp-ibm @dongreenberg @aasfaw
+machine_learning/**/* @woodsp-ibm @dongreenberg @aasfaw
+chemistry/**/* @woodsp-ibm @pbark @aasfaw
+finance/**/* @woodsp-ibm @stefan-woerner @aasfaw
+optimization/**/* @woodsp-ibm @stefan-woerner @aasfaw
 
 arts/* @attp @aasfaw @quantumjim @rraymondhp
 awards/**/* @attp @aasfaw @quantumjim @rraymondhp @pistoia


### PR DESCRIPTION
Marco Pistoia and Richard Chen removed as codeowners. Updated owners for Aqua and domains and includes the person responsible for that area of Aqua.

@dongreenberg @pbark @stefan-woerner for information



