### PR TITLE
Fixing Binder building error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: Qiskitenv
 dependencies:
 - python=3
-- pip=18
+- pip
 - matplotlib
 - notebook
 - ipywidgets

--- a/games/Quantum-Coin-Game.ipynb
+++ b/games/Quantum-Coin-Game.ipynb
@@ -977,5 +977,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
### Summary

Fixed #73 

### Details and comments

Fixed #73  by deleting the pip version requirement (for new Qiskit version pip 19 or above are required). Adapted minor version in Quantum-Coin-Game to avoid "Notebook validation failed" error message.
